### PR TITLE
Feature: fetch, test and log dip node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Supposed to be deployed in the central-data-node-deployment project, where it's 
 
 ## Building
 Calling `sbt assembly` generates .jar files in the ./core and ./connectors folders respectively. 
-These will be moved into the root folder and packaged and released as a docker image through a github action
-defined in ./.github/workflows/release.yml when triggering that action in github.
+These will be moved into the root folder and packaged and released as a Docker image through a GitHub action
+defined in ./.github/workflows/release.yml when triggering that action in GitHub.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ DNPM Central Clinical Node for Model Project (MVH): Component to send data submi
 Supposed to be deployed in the central-data-node-deployment project, where it's given a configuration directory.
 
 ## Building
-Calling `sbt assembly` generates .jar file sin the ./core and ./connectors folders respectively. 
+Calling `sbt assembly` generates .jar files in the ./core and ./connectors folders respectively. 
 These will be moved into the root folder and packaged and released as a docker image through a github action
 defined in ./.github/workflows/release.yml when triggering that action in github.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@
 DNPM Central Clinical Node for Model Project (MVH): Component to send data submission reports from DNPM to BfArM
 
 Supposed to be deployed in the central-data-node-deployment project, where it's given a configuration directory.
+
+## Building
+Calling `sbt assembly` generates .jar file sin the ./core and ./connectors folders respectively. 
+These will be moved into the root folder and packaged and released as a docker image through a github action
+defined in ./.github/workflows/release.yml when triggering that action in github.

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ ThisBuild / githubRepository := ownerRepo(1)
 
 
 ThisBuild / assemblyMergeStrategy := {
+  case "config.json"                             => MergeStrategy.discard
   case PathList("META-INF", "services", xs @ _*) => MergeStrategy.first
   case PathList("META-INF", xs @ _*)             => MergeStrategy.discard
   case "reference.conf"                          => MergeStrategy.concat

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val core = project
       dependencies.scalatest,
       dependencies.logback,
       dependencies.service_base,
-      dependencies.bfarm_dto_base,
+      dependencies.bfarm_dto_base
     ),
     assembly / assemblyJarName := "dnpm-ccdn-core.jar",
     assembly / mainClass       := Some("de.dnpm.ccdn.core.MVHReportingService")
@@ -58,7 +58,7 @@ lazy val connectors = project
       dependencies.scalamock,
       dependencies.play_ahc,
       dependencies.play_ahc_js,
-      dependencies.mongodb_driver,
+      dependencies.mongodb_driver
     ),
     assembly / assemblyJarName := "dnpm-ccdn-connectors.jar",
   )

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val core = project
       dependencies.logback,
       dependencies.service_base,
       dependencies.bfarm_dto_base,
-      dependencies.mongo4cats
+      dependencies.mongodb_driver
     ),
     assembly / assemblyJarName := "dnpm-ccdn-core.jar",
     assembly / mainClass       := Some("de.dnpm.ccdn.core.MVHReportingService")
@@ -80,7 +80,7 @@ lazy val dependencies =
     val play_ahc_js    = "org.playframework" %% "play-ws-standalone-json" % "3.0.7"
     val service_base   = "de.dnpm.dip"       %% "service-base"            % "1.3.1"
     val bfarm_dto_base = "de.dnpm"           %% "dnpm-bfarm-model-base"   % "1.0.1"
-    val mongo4cats   = "io.github.kirill5k" %% "mongo4cats-core"         % "0.7.13"
+    val mongodb_driver = "org.mongodb" % "mongodb-driver-sync" % "5.3.0"
   }
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val core = project
       dependencies.scalatest,
       dependencies.logback,
       dependencies.service_base,
-      dependencies.bfarm_dto_base
+      dependencies.bfarm_dto_base,
+      dependencies.mongo4cats
     ),
     assembly / assemblyJarName := "dnpm-ccdn-core.jar",
     assembly / mainClass       := Some("de.dnpm.ccdn.core.MVHReportingService")
@@ -79,6 +80,7 @@ lazy val dependencies =
     val play_ahc_js    = "org.playframework" %% "play-ws-standalone-json" % "3.0.7"
     val service_base   = "de.dnpm.dip"       %% "service-base"            % "1.3.1"
     val bfarm_dto_base = "de.dnpm"           %% "dnpm-bfarm-model-base"   % "1.0.1"
+    val mongo4cats   = "io.github.kirill5k" %% "mongo4cats-core"         % "0.7.13"
   }
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,6 @@ lazy val core = project
       dependencies.logback,
       dependencies.service_base,
       dependencies.bfarm_dto_base,
-      dependencies.mongodb_driver
     ),
     assembly / assemblyJarName := "dnpm-ccdn-core.jar",
     assembly / mainClass       := Some("de.dnpm.ccdn.core.MVHReportingService")
@@ -59,6 +58,7 @@ lazy val connectors = project
       dependencies.scalamock,
       dependencies.play_ahc,
       dependencies.play_ahc_js,
+      dependencies.mongodb_driver,
     ),
     assembly / assemblyJarName := "dnpm-ccdn-connectors.jar",
   )

--- a/connectors/src/main/resources/META-INF/services/de.dnpm.ccdn.core.PersistenceServiceProvider
+++ b/connectors/src/main/resources/META-INF/services/de.dnpm.ccdn.core.PersistenceServiceProvider
@@ -1,0 +1,1 @@
+de.dnpm.ccdn.connector.PersistenceServiceProviderImpl

--- a/connectors/src/main/scala/de/dnpm/ccdn/connector/DipConnectorImpl.scala
+++ b/connectors/src/main/scala/de/dnpm/ccdn/connector/DipConnectorImpl.scala
@@ -129,7 +129,7 @@ with Logging
   import java.util.concurrent.atomic.AtomicReference
 
 
-  private val sitesConfig: AtomicReference[Map[Code[Site],String]] =
+  private[connector] val sitesConfig: AtomicReference[Map[Code[Site],String]] =
     new AtomicReference(Map.empty)
 
   private implicit lazy val executor: ScheduledExecutorService =
@@ -258,4 +258,24 @@ with Logging
       } 
     )
 
+  /**
+   * Asks the given site what version it is and returns the version string (extracted from json) as Right
+   * If the communication fails or the returned json object has an unexpected format, the entire content is returned as Left
+   */
+  override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext): Future[Either[String, String]] =
+    request(site, "/api/peer2peer/meta-info")
+      .get()
+      .map(
+        resp => resp.status match {
+          case 200 =>
+            (resp.body[JsValue] \ "version")
+              .asOpt[String]
+              .toRight(s"No 'version' field in meta-info response from site $site: ${resp.body}")
+          case _ =>
+            s"Meta-info request for site $site failed with status ${resp.status} ${resp.statusText}: ${resp.body}".asLeft
+        }
+      )
+      .recover {
+        case t => t.getMessage.asLeft
+      }
 }

--- a/connectors/src/main/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImpl.scala
+++ b/connectors/src/main/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImpl.scala
@@ -1,0 +1,66 @@
+package de.dnpm.ccdn.connector
+
+
+import java.time.Instant
+import com.mongodb.client.MongoClients
+import org.bson.Document
+import de.dnpm.dip.util.Logging
+import de.dnpm.ccdn.core.{
+  ResponsivityReport,
+  PersistenceService,
+  PersistenceServiceProvider
+}
+import scala.util.Properties.{envOrNone, propOrNone}
+
+
+final class PersistenceServiceProviderImpl extends PersistenceServiceProvider
+{
+  override def getInstance: PersistenceService =
+    MongodbPersistenceServiceImpl.instance
+}
+
+object MongodbPersistenceServiceImpl
+{
+  lazy val instance = new MongodbPersistenceServiceImpl
+}
+
+final class MongodbPersistenceServiceImpl extends PersistenceService with Logging
+{
+
+  private val mongoUri: Option[String] =
+    envOrNone("CCDN_MONGODB_URI").orElse(propOrNone("ccdn.mongodb.uri"))
+
+  override def writeSiteAvailabilityReports(
+    reports: Iterable[ResponsivityReport],
+    now: Instant
+  ): Unit =
+    mongoUri match {
+      case Some(uri) =>
+        try {
+          val client = MongoClients.create(uri)
+          try {
+            val coll = client.getDatabase("ccdn").getCollection("siteAvailabilityReports")
+            val docs = new java.util.ArrayList[Document]()
+            reports.foreach { r =>
+              docs.add(
+                new Document("site", r.site.value)
+                  .append("responsivity", r.responsivity.toString)
+                  .append("apiVersion", r.versionString.getOrElse("???"))
+                  .append("timestamp", java.util.Date.from(now))
+              )
+            }
+            coll.insertMany(docs)
+            log.debug("Successfully persisted responsivity logs")
+          } finally {
+            client.close()
+          }
+        } catch {
+          case exc: Exception =>
+            log.warn(s"Failed to persist responsivity logs. Exception: ${exc.getMessage}")
+        }
+      case None =>
+        log.warn("CCDN_MONGODB_URI is not configured; site availability " +
+          "reports will not be persisted")
+    }
+
+}

--- a/connectors/src/main/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImpl.scala
+++ b/connectors/src/main/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImpl.scala
@@ -34,7 +34,7 @@ final class MongodbPersistenceServiceImpl extends PersistenceService with Loggin
     reports: Iterable[ResponsivityReport],
     now: Instant
   ): Unit =
-    mongoUri match {
+    if(reports.nonEmpty) mongoUri match {
       case Some(uri) =>
         try {
           val client = MongoClients.create(uri)
@@ -61,6 +61,9 @@ final class MongodbPersistenceServiceImpl extends PersistenceService with Loggin
       case None =>
         log.warn("CCDN_MONGODB_URI is not configured; site availability " +
           "reports will not be persisted")
+    }
+    else {
+      log.warn("Empty set of reports passed to writeSiteAvailabilityReports")
     }
 
 }

--- a/connectors/src/main/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImpl.scala
+++ b/connectors/src/main/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImpl.scala
@@ -21,49 +21,52 @@ final class PersistenceServiceProviderImpl extends PersistenceServiceProvider
 
 object MongodbPersistenceServiceImpl
 {
-  lazy val instance = new MongodbPersistenceServiceImpl
+  private val MONGODBURIJVMPROP = "ccdn.mongodb.uri"
+  private val MONGODBURIENVVAR  = "CCDN_MONGODB_URI"
+
+  lazy val instance = new MongodbPersistenceServiceImpl(
+    envOrNone(MONGODBURIENVVAR).orElse(propOrNone(MONGODBURIJVMPROP))
+  )
 }
 
-final class MongodbPersistenceServiceImpl extends PersistenceService with Logging
+final class MongodbPersistenceServiceImpl(
+  val mongoUri: Option[String]
+) extends PersistenceService with Logging
 {
 
-  private val mongoUri: Option[String] =
-    envOrNone("CCDN_MONGODB_URI").orElse(propOrNone("ccdn.mongodb.uri"))
+  mongoUri match {
+    case Some(uri) => log.debug(s"MongoDB URI: $uri")
+    case None      => log.warn("MongoDB URI is not configured; site availability reports will not be persisted")
+  }
 
   override def writeSiteAvailabilityReports(
     reports: Iterable[ResponsivityReport],
     now: Instant
   ): Unit =
-    if(reports.nonEmpty) mongoUri match {
-      case Some(uri) =>
+    if (reports.nonEmpty) mongoUri.foreach { uri =>
+      try {
+        val client = MongoClients.create(uri)
         try {
-          val client = MongoClients.create(uri)
-          try {
-            val coll = client.getDatabase("ccdn").getCollection("siteAvailabilityReports")
-            val docs = new java.util.ArrayList[Document]()
-            reports.foreach { r =>
-              docs.add(
-                new Document("site", r.site.value)
-                  .append("responsivity", r.responsivity.toString)
-                  .append("apiVersion", r.versionString.getOrElse("???"))
-                  .append("timestamp", java.util.Date.from(now))
-              )
-            }
-            coll.insertMany(docs)
-            log.debug("Successfully persisted responsivity logs")
-          } finally {
-            client.close()
+          val coll = client.getDatabase("ccdn").getCollection("siteAvailabilityReports")
+          val docs = new java.util.ArrayList[Document]()
+          reports.foreach { r =>
+            docs.add(
+              new Document("site", r.site.value)
+                .append("responsivity", r.responsivity.toString)
+                .append("apiVersion", r.versionString.getOrElse("???"))
+                .append("timestamp", java.util.Date.from(now))
+            )
           }
-        } catch {
-          case exc: Exception =>
-            log.warn(s"Failed to persist responsivity logs. Exception: ${exc.getMessage}")
+          coll.insertMany(docs)
+          log.debug("Successfully persisted responsivity logs")
+        } finally {
+          client.close()
         }
-      case None =>
-        log.warn("CCDN_MONGODB_URI is not configured; site availability " +
-          "reports will not be persisted")
+      } catch {
+        case exc: Exception =>
+          log.warn(s"Failed to persist responsivity logs. Exception: ${exc.getMessage}")
+      }
     }
-    else {
-      log.warn("Empty set of reports passed to writeSiteAvailabilityReports")
-    }
+    else log.warn("Empty set of reports passed to writeSiteAvailabilityReports")
 
 }

--- a/connectors/src/test/scala/de/dnpm/ccdn/connector/BrokerDipConnectorImplTests.scala
+++ b/connectors/src/test/scala/de/dnpm/ccdn/connector/BrokerDipConnectorImplTests.scala
@@ -1,0 +1,101 @@
+package de.dnpm.ccdn.connector
+
+import de.dnpm.dip.coding.Code
+import de.dnpm.dip.model.Site
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.flatspec.AsyncFlatSpec
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws._
+
+import scala.concurrent.Future
+
+class BrokerDipConnectorImplTests extends AsyncFlatSpec
+  with AsyncMockFactory
+{
+
+  behavior of "BrokerDipConnectorImpl"
+
+  private val baseUrl = "https://uktest.de"
+  private val testSite = Code[Site]("UKT")
+  private val expectedFullApiVersionRequestUrl = "https://uktest.de/api/peer2peer/meta-info"
+
+  trait CustomRequest extends StandaloneWSRequest with DefaultBodyWritables {
+    type Self = CustomRequest
+    type Response = CustomResponse
+  }
+  trait CustomResponse extends StandaloneWSResponse
+
+  /**
+   * @param metaInfoResponse the Future returned by get() on the meta-info mock request
+   * @param metaInfoUrl the exact URL the mock expects; use a literal string in tests that verify URL correctness
+   */
+  private class TestFixture(
+    metaInfoResponse: Future[_ <: CustomResponse],
+    metaInfoUrl: String = s"$baseUrl/api/peer2peer/meta-info"
+  ) {
+    val mockHttpClient: StandaloneWSClient = stub[StandaloneWSClient]
+
+    // Stub /sites so that the connector constructor does not fail during initialisation
+    private val mockSitesRequest: CustomRequest = stub[CustomRequest]
+    (mockHttpClient.url _).when(s"$baseUrl/sites").returns(mockSitesRequest)
+    (mockSitesRequest.withRequestTimeout _).when(*).returns(mockSitesRequest)
+    (() => mockSitesRequest.get()).when().returns(
+      Future.failed(new Exception("sites config not relevant in this test"))
+    )
+
+    val connector = new BrokerDipConnectorImpl(
+      mockHttpClient,
+      BrokerDipConnectorImpl.Config(baseUrl, Some(10), None)
+    )
+
+    // The sites request fails above, so inject the test site directly.
+    connector.sitesConfig.set(Map(testSite -> "uktest.de"))
+
+    // Stub the meta-info endpoint
+    val mockMetaRequest: CustomRequest = stub[CustomRequest]
+    (mockHttpClient.url _).when(metaInfoUrl).returns(mockMetaRequest)
+    (mockMetaRequest.withRequestTimeout _).when(*).returns(mockMetaRequest)
+    (mockMetaRequest.withVirtualHost _).when(*).returns(mockMetaRequest)
+    (() => mockMetaRequest.get()).when().returns(metaInfoResponse)
+  }
+
+
+  it must "return the version string when the meta-info endpoint returns a JSON body with a 'version' field" in {
+    val mockResponse: CustomResponse = stub[CustomResponse]
+    (() => mockResponse.status).when().returns(200)
+    (mockResponse.body[JsValue](_: BodyReadable[JsValue])).when(*).returns(
+      Json.obj("version" -> "2.5.1", "unrelated" -> "field")
+    )
+
+    // Literal URL verifies that getApiVersion targets exactly this endpoint
+    val fixture = new TestFixture(
+      Future.successful(mockResponse),
+      expectedFullApiVersionRequestUrl
+    )
+    fixture.connector.getApiVersion(testSite).map { result =>
+      assertResult(Right("2.5.1"))(result)
+    }
+  }
+
+  it must "return Left when the meta-info endpoint returns a JSON body without a 'version' field" in {
+    val responseBodyJson = Json.obj("name" -> "dip-node", "status" -> "running")
+    val mockResponse: CustomResponse = stub[CustomResponse]
+    (() => mockResponse.status).when().returns(200)
+    (mockResponse.body[JsValue](_: BodyReadable[JsValue])).when(*).returns(responseBodyJson)
+    (() => mockResponse.body).when().returns(responseBodyJson.toString)
+
+    val fixture = new TestFixture(Future.successful(mockResponse))
+    fixture.connector.getApiVersion(testSite).map { result =>
+      assert(result.isLeft, s"Expected Left for response without 'version' field, got: $result")
+    }
+  }
+
+  it must "return Left containing the exception message when the connection to the site fails" in {
+    val errorMsg = "Connection refused: uktest.de/443"
+
+    val fixture = new TestFixture(Future.failed(new Exception(errorMsg)))
+    fixture.connector.getApiVersion(testSite).map { result =>
+      assertResult(Left(errorMsg))(result)
+    }
+  }
+}

--- a/connectors/src/test/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImplTests.scala
+++ b/connectors/src/test/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImplTests.scala
@@ -1,0 +1,37 @@
+package de.dnpm.ccdn.connector
+
+
+import java.time.Instant
+import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers._
+import org.slf4j.LoggerFactory
+import scala.jdk.CollectionConverters._
+
+
+final class MongodbPersistenceServiceImplTests extends AnyFlatSpec
+{
+
+  behavior of "MongodbPersistenceServiceImpl"
+
+  it must "log a warning when called with an empty set of reports" in {
+    val impl = new MongodbPersistenceServiceImpl
+    val logger =
+      LoggerFactory.getLogger(classOf[MongodbPersistenceServiceImpl])
+        .asInstanceOf[Logger]
+    val appender = new ListAppender[ILoggingEvent]
+    appender.start()
+    logger.addAppender(appender)
+
+    try {
+      impl.writeSiteAvailabilityReports(Seq.empty, Instant.now())
+    } finally {
+      val _ = logger.detachAppender(appender) // value discard is compile error
+    }
+
+    appender.list.asScala.filter(_.getLevel == Level.WARN) must not be empty
+  }
+
+}

--- a/connectors/src/test/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImplTests.scala
+++ b/connectors/src/test/scala/de/dnpm/ccdn/connector/MongodbPersistenceServiceImplTests.scala
@@ -17,7 +17,7 @@ final class MongodbPersistenceServiceImplTests extends AnyFlatSpec
   behavior of "MongodbPersistenceServiceImpl"
 
   it must "log a warning when called with an empty set of reports" in {
-    val impl = new MongodbPersistenceServiceImpl
+    val impl = new MongodbPersistenceServiceImpl(Some("somewhere"))
     val logger =
       LoggerFactory.getLogger(classOf[MongodbPersistenceServiceImpl])
         .asInstanceOf[Logger]

--- a/connectors/src/test/scala/de/dnpm/ccdn/connector/SPITests.scala
+++ b/connectors/src/test/scala/de/dnpm/ccdn/connector/SPITests.scala
@@ -41,7 +41,7 @@ final class SPITests extends AnyFlatSpec
           Failure(t)
       }
 
-  private val siteAvailabilityReporter =
+  private val persistenceService =
     PersistenceService.getInstance
 
 
@@ -49,7 +49,7 @@ final class SPITests extends AnyFlatSpec
     assert(dipConnector.isSuccess)
     assert(bfarmConnector.isSuccess)
     assert(reportQueue.isSuccess)
-    assert(siteAvailabilityReporter.isSuccess)
+    assert(persistenceService.isSuccess)
   }
 
 }

--- a/connectors/src/test/scala/de/dnpm/ccdn/connector/SPITests.scala
+++ b/connectors/src/test/scala/de/dnpm/ccdn/connector/SPITests.scala
@@ -4,7 +4,7 @@ package de.dnpm.ccdn.connector
 import java.nio.file.Files.createTempDirectory
 import scala.util.Failure
 import org.scalatest.flatspec.AnyFlatSpec
-import de.dnpm.ccdn.core.ReportRepository
+import de.dnpm.ccdn.core.{ReportRepository, PersistenceService}
 import de.dnpm.ccdn.core.bfarm.BfarmConnector
 import de.dnpm.ccdn.core.dip.DipConnector
 
@@ -35,17 +35,21 @@ final class SPITests extends AnyFlatSpec
 
   private val reportQueue =
     ReportRepository.getInstance
-      .recoverWith { 
+      .recoverWith {
         case t =>
           t.printStackTrace
           Failure(t)
       }
+
+  private val siteAvailabilityReporter =
+    PersistenceService.getInstance
 
 
   "SPI Loaders" must "load implementations" in {
     assert(dipConnector.isSuccess)
     assert(bfarmConnector.isSuccess)
     assert(reportQueue.isSuccess)
+    assert(siteAvailabilityReporter.isSuccess)
   }
 
 }

--- a/core/src/main/scala/de/dnpm/ccdn/core/Config.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/Config.scala
@@ -32,8 +32,8 @@ final case class Config
 ){
 
   private val MONGODBURIJVMPROP = "ccdn.mongodb.uri"
-  private val MONGODDBURIENVVAR = "CCDN_MONGODB_URI"
-  val mongoUri: Option[String] = envOrNone(MONGODDBURIENVVAR).orElse(propOrNone(MONGODBURIJVMPROP))
+  private val MONGODBURIENVVAR = "CCDN_MONGODB_URI"
+  val mongoUri: Option[String] = envOrNone(MONGODBURIENVVAR).orElse(propOrNone(MONGODBURIJVMPROP))
 
   def activeUseCases: Set[UseCase.Value] =
     dataNodeIds.keySet

--- a/core/src/main/scala/de/dnpm/ccdn/core/Config.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/Config.scala
@@ -21,8 +21,6 @@ import de.dnpm.ccdn.core.bfarm.{
   GDC
 }
 
-import scala.util.Properties.{envOrNone, propOrNone}
-
 
 final case class Config
 (
@@ -31,11 +29,7 @@ final case class Config
   sites: Map[Code[Site],Config.SiteInfo]
 ){
 
-  private val MONGODBURIJVMPROP = "ccdn.mongodb.uri"
-  private val MONGODBURIENVVAR = "CCDN_MONGODB_URI"
-  val mongoUri: Option[String] = envOrNone(MONGODBURIENVVAR).orElse(propOrNone(MONGODBURIJVMPROP))
-
-  def activeUseCases: Set[UseCase.Value] =
+  def activeUseCases:Set[UseCase.Value] =
     dataNodeIds.keySet
 
   def submitterId(site: Code[Site]): Id[Site] =

--- a/core/src/main/scala/de/dnpm/ccdn/core/Config.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/Config.scala
@@ -21,6 +21,8 @@ import de.dnpm.ccdn.core.bfarm.{
   GDC
 }
 
+import scala.util.Properties.{envOrNone, propOrNone}
+
 
 final case class Config
 (
@@ -29,7 +31,11 @@ final case class Config
   sites: Map[Code[Site],Config.SiteInfo]
 ){
 
-  def activeUseCases =
+  private val MONGODBURIJVMPROP = "ccdn.mongodb.uri"
+  private val MONGODDBURIENVVAR = "CCDN_MONGODB_URI"
+  val mongoUri: Option[String] = envOrNone(MONGODDBURIENVVAR).orElse(propOrNone(MONGODBURIJVMPROP))
+
+  def activeUseCases: Set[UseCase.Value] =
     dataNodeIds.keySet
 
   def submitterId(site: Code[Site]): Id[Site] =

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -9,10 +9,8 @@ import scala.concurrent.duration.Duration
 import scala.util.Success
 import cats.syntax.either._
 import cats.syntax.traverse._
-import cats.effect.IO
-import mongo4cats.bson.Document
-import mongo4cats.bson.syntax._
-import mongo4cats.client.MongoClient
+import com.mongodb.client.MongoClients
+import org.bson.Document
 import de.dnpm.dip.util.Logging
 import de.dnpm.dip.model.{NGSReport, Site}
 import de.dnpm.dip.service.mvh.Submission
@@ -77,21 +75,27 @@ with BatchingUtil
                                            now: Instant): Unit =
     config.mongoUri match {
       case Some(uri) =>
-        import cats.effect.unsafe.implicits.global
-        MongoClient.fromConnectionString[IO](uri).use { client =>
-          for {
-            db   <- client.getDatabase("ccdn")
-            coll <- db.getCollection("siteAvailabilityReports")
-            docs  = reports.map(r => Document(
-              "site" := r.site.value,
-              "responsivity" := r.responsivity.toString,
-              "apiVersion" := r.versionString.getOrElse("???"), //would happen only for failures
-              "timestamp" := now)).toList
-            _    <- coll.insertMany(docs)
-          } yield ()
-        }.unsafeRunAsync {
-          case Left(exc) => log.warn(s"Failed to persist responsivity logs. Exception: ${exc.getMessage}")
-          case Right(_) => log.debug("Successfully persisted responsivity logs")
+        try { //making mongoDB client
+          val client = MongoClients.create(uri)
+          try { //communicating with it, closing it finally
+            val coll = client.getDatabase("ccdn").getCollection("siteAvailabilityReports")
+            val docs = new java.util.ArrayList[Document]()
+            reports.foreach { r =>
+              docs.add(
+                new Document("site", r.site.value)
+                  .append("responsivity", r.responsivity.toString)
+                  .append("apiVersion", r.versionString.getOrElse("???"))
+                  .append("timestamp", java.util.Date.from(now))
+              )
+            }
+            coll.insertMany(docs)
+            log.debug("Successfully persisted responsivity logs")
+          } finally {
+            client.close()
+          }
+        } catch {
+          case exc: Exception =>
+            log.warn(s"Failed to persist responsivity logs. Exception: ${exc.getMessage}")
         }
       case None =>
         log.warn("CCDN_MONGODB_URI is not configured; site availability " +

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -90,7 +90,10 @@ with BatchingUtil
               "timestamp" := now)).toList
             _    <- coll.insertMany(docs)
           } yield ()
-        }.unsafeRunAndForget()
+        }.unsafeRunAsync {
+          case Left(exc) => log.warn(s"Failed to persist responsivity logs. Exception: ${exc.getMessage}")
+          case Right(_) => log.debug("Successfully persisted responsivity logs")
+        }
       case None =>
         log.warn("CCDN_MONGODB_URI is not configured; site availability " +
           "reports will not be persisted")

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -200,6 +200,7 @@ with BatchingUtil
     } yield {
       persistenceService.writeSiteAvailabilityReports(
         coalesceResponsivityReports(responseLog.asScala), Instant.now(clock))
+      log.debug("Reporting workflow completed")
     }
   }
 

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -313,8 +313,8 @@ with BatchingUtil
           case Right(v) if isSiteApiVersionSupported(v) =>
             availabilityBuffer += ResponsivityReport(site, Responsivity.success,Some(v))
             Some(site)
-          case Right(_) =>
-            availabilityBuffer += ResponsivityReport(site, Responsivity.success)
+          case Right(v) =>
+            availabilityBuffer += ResponsivityReport(site, Responsivity.success, Some(v))
             None
           case Left(_) =>
             availabilityBuffer += ResponsivityReport(site, Responsivity.failure)

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -69,6 +69,9 @@ class MVHReportingService
 extends Logging
 with BatchingUtil
 {
+  /**
+   * Serves local time. Abstracted for the purpose of unit tests
+   */
   private[core] var clock: Clock = Clock.systemUTC()
 
   private def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport],
@@ -113,7 +116,7 @@ with BatchingUtil
    * ([[confirmSubmissions]]). The interval is retrieved from [[config#polling]]
    *
    * Before polling for new reports, the [[pollingQueue]] is checked for preexisting items,
-   * which are pro  cessed before polling for new items in [[pollReports]]
+   * which are processed before polling for new items in [[pollReports]]
    *
    * The state of this process is stored in the [[pollingQueue]] and in the
    * [[Submission.Report.status]] of it's items.
@@ -325,14 +328,14 @@ with BatchingUtil
       .filter(configVal => validSites.contains(configVal._1))
       .sortBy(_._1.value) // Just for easier log reading: sort the sites alphabetically
       .traverse {
-        case (curSite,info) =>
+        case (site,info) =>
           info.useCases.intersect(config.activeUseCases) // ensure only active use cases are polled
             .toList
             .traverse { useCase =>
 
-              log.debug(s"Polling $useCase SubmissionReports of $curSite")
+              log.debug(s"Polling $useCase SubmissionReports of $site")
               dipConnector.submissionReports(
-                curSite,
+                site,
                 useCase,
                 Submission.Report.Filter(
                   status = Some(Set(Submission.Report.Status.Unsubmitted))
@@ -345,15 +348,15 @@ with BatchingUtil
 
                 case Success(Left(err)) =>
                   log.error(s"Problem polling $useCase SubmissionReports of " +
-                    s"site $curSite: $err")
-                  availabilityBuffer += ResponsivityReport(curSite,Responsivity.failure)
+                    s"site $site: $err")
+                  availabilityBuffer += ResponsivityReport(site,Responsivity.failure)
               }
               // Recover lest the Future traversal be "short-circuited" into a failed Future
               .recover {
                 case t =>
                   log.error(s"Error(s) occurred polling $useCase " +
-                    s"SubmissionReports of $curSite", t)
-                  availabilityBuffer += ResponsivityReport(curSite,Responsivity.failure)
+                    s"SubmissionReports of $site", t)
+                  availabilityBuffer += ResponsivityReport(site,Responsivity.failure)
                   t.getMessage.asLeft
               }
           }

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -86,6 +86,7 @@ with BatchingUtil
             docs  = reports.map(r => Document(
               "site" := r.site.value,
               "responsivity" := r.responsivity.toString,
+              "apiVersion" := r.versionString.getOrElse("???"), //would happen only for failures
               "timestamp" := now)).toList
             _    <- coll.insertMany(docs)
           } yield ()
@@ -177,6 +178,33 @@ with BatchingUtil
   }
 
   /**
+   * The functions in the [[DipConnector]] that communicate with external sites
+   * return a report about connectivity. To end up with a single report per site
+   * per attempt, this function coalesces the information collected in.
+   * [[conductReportingWorkflow]]
+   * @param responseLog collected base data
+   * @return one report per site
+   */
+  private[core] def coalesceResponsivityReports(responseLog: ListBuffer[ResponsivityReport]) =
+    responseLog
+      .groupBy(_.site)
+      .map { case (site, reports) =>
+        val responsivity =
+          if (reports.forall(_.responsivity == Responsivity.success))
+            Responsivity.success
+          else if (reports.forall(_.responsivity == Responsivity.failure))
+            Responsivity.failure
+          else
+            Responsivity.mixedSuccess
+        //strictly speaking this picks a random version string, but that
+        // shouldn't be an issue, because only the one request to
+        // getApiCompatibleDipSites would return a ResponsivityReport with a
+        // version and all version info should be consistent anyway
+        val version = reports.flatMap(_.versionString).headOption
+        ResponsivityReport(site, responsivity, version)
+      }
+
+  /**
    * Executes one full cycle of the reporting workflow: checks site API versions,
    * drains any pre-existing queue entries, polls new reports, uploads them to
    * BfArM, and confirms back. Logs responsivity into [[responsivitySink]]
@@ -186,20 +214,6 @@ with BatchingUtil
     log.info(s"Conducting scheduled reporting workflow " +
       s"${if (pollingQueue.exists(_ => true)) "with" else "without"} " +
       s"preexisting items in the queue")
-
-    def coalesceResponsivityReports(responseLog: ListBuffer[ResponsivityReport]) =
-      responseLog
-        .groupBy(_.site)
-        .map { case (site, reports) =>
-          val responsivity =
-            if (reports.forall(_.responsivity == Responsivity.success))
-              Responsivity.success
-            else if (reports.forall(_.responsivity == Responsivity.failure))
-              Responsivity.failure
-            else
-              Responsivity.mixedSuccess
-          ResponsivityReport(site, responsivity)
-        }
 
     //responseLog stores notes about how well a site could be communicated with.
     // checkSiteApiVersion will store a success item for every site that was
@@ -231,7 +245,7 @@ with BatchingUtil
     val mixedSuccess = Value("partial")
     val failure = Value("offline")
   }
-  case class ResponsivityReport(site:Code[Site],responsivity: Responsivity.Value)
+  case class ResponsivityReport(site:Code[Site],responsivity: Responsivity.Value, versionString:Option[String] = None)
 
 
   def stop(): Unit = {
@@ -297,7 +311,7 @@ with BatchingUtil
       dipConnector.getApiVersion(site)
         .map {
           case Right(v) if isSiteApiVersionSupported(v) =>
-            availabilityBuffer += ResponsivityReport(site, Responsivity.success)
+            availabilityBuffer += ResponsivityReport(site, Responsivity.success,Some(v))
             Some(site)
           case Right(_) =>
             availabilityBuffer += ResponsivityReport(site, Responsivity.success)

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -3,14 +3,13 @@ package de.dnpm.ccdn.core
 
 import java.time.{Clock, Instant, LocalDate, LocalTime}
 import java.time.temporal.ChronoUnit
-import java.util.concurrent.{ConcurrentLinkedQueue, Executors, ScheduledExecutorService, TimeUnit, Future => JavaFuture}
+import java.util.concurrent.{ConcurrentLinkedQueue, Executors,
+  ScheduledExecutorService, TimeUnit, Future => JavaFuture}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 import scala.util.Success
 import cats.syntax.either._
 import cats.syntax.traverse._
-import com.mongodb.client.MongoClients
-import org.bson.Document
 import de.dnpm.dip.util.Logging
 import de.dnpm.dip.model.{NGSReport, Site}
 import de.dnpm.dip.service.mvh.Submission
@@ -18,7 +17,6 @@ import Submission.Report.Status.{Submitted, Unsubmitted}
 import de.dnpm.ccdn.core.bfarm.BfarmConnector
 import de.dnpm.ccdn.core.dip.DipConnector
 import de.dnpm.dip.coding.Code
-
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 
@@ -31,7 +29,8 @@ object MVHReportingService
       Config.instance,
       ReportRepository.getInstance.get,
       dip.DipConnector.getInstance.get,
-      bfarm.BfarmConnector.getInstance.get
+      bfarm.BfarmConnector.getInstance.get,
+      PersistenceService.getInstance.get
     )
 
   /**
@@ -59,7 +58,8 @@ class MVHReportingService
   config: Config,
   private[core] val pollingQueue: ReportRepository,
   private[core] val dipConnector: DipConnector,
-  private[core] val bfarmConnector: BfarmConnector
+  private[core] val bfarmConnector: BfarmConnector,
+  private[core] val persistenceService: PersistenceService
 )(
   implicit ec: ExecutionContext
 )
@@ -70,45 +70,6 @@ with BatchingUtil
    * Serves local time. Abstracted for the purpose of unit tests
    */
   private[core] var clock: Clock = Clock.systemUTC()
-
-  private def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport],
-                                           now: Instant): Unit =
-    config.mongoUri match {
-      case Some(uri) =>
-        try { //making mongoDB client
-          val client = MongoClients.create(uri)
-          try { //communicating with it, closing it finally
-            val coll = client.getDatabase("ccdn").getCollection("siteAvailabilityReports")
-            val docs = new java.util.ArrayList[Document]()
-            reports.foreach { r =>
-              docs.add(
-                new Document("site", r.site.value)
-                  .append("responsivity", r.responsivity.toString)
-                  .append("apiVersion", r.versionString.getOrElse("???"))
-                  .append("timestamp", java.util.Date.from(now))
-              )
-            }
-            coll.insertMany(docs)
-            log.debug("Successfully persisted responsivity logs")
-          } finally {
-            client.close()
-          }
-        } catch {
-          case exc: Exception =>
-            log.warn(s"Failed to persist responsivity logs. Exception: ${exc.getMessage}")
-        }
-      case None =>
-        log.warn("CCDN_MONGODB_URI is not configured; site availability " +
-          "reports will not be persisted")
-    }
-
-  /**
-   * Abstraction of logging responsivity reports for the purpose of having
-   * customization in unit tests
-   */
-  private[core] var responsivitySink: (Iterable[ResponsivityReport], Instant) => Unit =
-    writeSiteAvailabilityReports
-
 
   /**
    * Executes the runnable in [[pollingTask]] in regular intervals
@@ -213,7 +174,7 @@ with BatchingUtil
   /**
    * Executes one full cycle of the reporting workflow: checks site API versions,
    * drains any pre-existing queue entries, polls new reports, uploads them to
-   * BfArM, and confirms back. Logs responsivity into [[responsivitySink]]
+   * BfArM, and confirms back. Logs responsivity via [[PersistenceService]]
    */
   private[core] def conductReportingWorkflow(): Future[Unit] = {
 
@@ -237,22 +198,10 @@ with BatchingUtil
       _ <- uploadReports
       _ <- confirmSubmissions(responseLog)
     } yield {
-      responsivitySink(coalesceResponsivityReports(responseLog.asScala),Instant.now(clock))
+      persistenceService.writeSiteAvailabilityReports(
+        coalesceResponsivityReports(responseLog.asScala), Instant.now(clock))
     }
   }
-
-  /**
-   * How a site responded to requests. A record can consist of multiple items
-   * for the same site and can be reduced to single value. Mixed reports reduce
-   * to [[mixedSuccess]]
-   */
-  object Responsivity extends Enumeration {
-    val success = Value("fully")
-    val mixedSuccess = Value("partial")
-    val failure = Value("offline")
-  }
-  case class ResponsivityReport(site:Code[Site],responsivity: Responsivity.Value, versionString:Option[String] = None)
-
 
   def stop(): Unit = {
     log.info("Stopping MVH Reporting service")

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -1,7 +1,7 @@
 package de.dnpm.ccdn.core
 
 
-import java.time.LocalTime
+import java.time.{Instant, LocalTime}
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.{Executors, ScheduledExecutorService}
 import java.util.concurrent.{TimeUnit, Future => JavaFuture}
@@ -14,11 +14,14 @@ import mongo4cats.bson.Document
 import mongo4cats.bson.syntax._
 import mongo4cats.client.MongoClient
 import de.dnpm.dip.util.Logging
-import de.dnpm.dip.model.NGSReport
+import de.dnpm.dip.model.{NGSReport, Site}
 import de.dnpm.dip.service.mvh.Submission
 import Submission.Report.Status.{Submitted, Unsubmitted}
 import de.dnpm.ccdn.core.bfarm.BfarmConnector
 import de.dnpm.ccdn.core.dip.DipConnector
+import de.dnpm.dip.coding.Code
+
+import scala.collection.mutable.ListBuffer
 
 
 object MVHReportingService
@@ -66,6 +69,23 @@ extends Logging
 with BatchingUtil
 {
 
+  private val mongoUri: Option[String] = sys.env.get("CCDN_MONGODB_URI") //TODO maybe put this into config
+
+  private def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport]): Unit =
+    mongoUri.foreach { uri =>
+      import cats.effect.unsafe.implicits.global
+      MongoClient.fromConnectionString[IO](uri).use { client =>
+        for {
+          db   <- client.getDatabase("ccdn")
+          coll <- db.getCollection("siteAvailabilityReports")
+          now   = Instant.now
+          docs  = reports.map(r => Document("site" := r.site.value, "responsivity" := r.responsivity.toString, "timestamp" := now)).toList
+          _    <- coll.insertMany(docs)
+        } yield ()
+      }.unsafeRunAndForget()
+    }
+
+
   /**
    * Executes the runnable in [[pollingTask]] in regular intervals
    */
@@ -79,7 +99,7 @@ with BatchingUtil
    * The interval is retrieved from [[config#polling]]
    *
    * Before polling for new reports, the [[pollingQueue]] is checked for preexisting items,
-   * which are processed before polling for new items in [[pollReports]]
+   * which are pro  cessed before polling for new items in [[pollReports]]
    *
    * The state of this process is stored in the [[pollingQueue]] and in the
    * [[Submission.Report.status]] of it's items.
@@ -101,6 +121,7 @@ with BatchingUtil
     log.info("Starting MVH Reporting service")
     log.info(s"Active Use Cases: ${config.activeUseCases.mkString(", ")}")
     log.info(s"Active sites: ${config.sites.keys.toList.sortBy(_.value).mkString(", ")}")
+    log.info(s"Mongodb uri: ${mongoUri}")
 
     val period =
       config.polling.period*toSeconds(config.polling.timeUnit)
@@ -122,16 +143,36 @@ with BatchingUtil
       Some(
         pollingExecutor.scheduleAtFixedRate(
           () => {
-            log.info(s"Conducting scheduled reporting workflow ${if(pollingQueue.exists(_ => true)) "with" else "without"} preexisting items in the queue")
+            log.info(s"Conducting scheduled reporting workflow ${if (pollingQueue.exists(_ => true)) "with" else "without"} preexisting items in the queue")
+
+            //responseLog stores notes about how well a site could be communicated with.
+            // checkSiteApiVersion will store a success item for every site that was
+            // available, so it is sufficient for the other functions to merely report
+            // failures. The endresult is reduced into a single value per site after the for loop.
+            val responseLog: ListBuffer[ResponsivityReport] = ListBuffer()
+
             for {
+              validSites <- checkSiteApiVersion(responseLog)
               // Start by draining the report queue, if non-empty (in case the service had been interrupted) and
               // it thus contains reports whose upload hasn't been confirmed to the origin DIP), in order to avoid polling them again
               _ <- if (pollingQueue.exists(_.status == Unsubmitted)) uploadReports else Future.unit
-              _ <- if (pollingQueue.exists(_.status == Submitted)) confirmSubmissions else Future.unit
-              _ <- pollReports
+              _ <- if (pollingQueue.exists(_.status == Submitted)) confirmSubmissions(responseLog) else Future.unit
+              _ <- pollReports(validSites,responseLog)
               _ <- uploadReports
-              _ <- confirmSubmissions
-            } yield ()
+              _ <- confirmSubmissions(responseLog)
+            } yield {
+              writeSiteAvailabilityReports(
+                responseLog
+                  .groupBy(_.site)
+                  .map { case (site, reports) =>
+                    val responsivity =
+                      if (reports.forall(_.responsivity == Responsivity.success)) Responsivity.success
+                      else if (reports.forall(_.responsivity == Responsivity.failure)) Responsivity.failure
+                      else Responsivity.mixedSuccess
+                    ResponsivityReport(site, responsivity)
+                  }
+              )
+            }
             ()
           },
           delay,
@@ -140,6 +181,17 @@ with BatchingUtil
         )
       )
   }
+
+  /**
+   * How a site responded to requests. A record can consist of multiple items
+   * for the same site and can be reduced to single value. Mixed reports reduce to [[mixedSuccess]]
+   */
+  object Responsivity extends Enumeration {
+    val success = Value("fully")
+    val mixedSuccess = Value("partial")
+    val failure = Value("offline")
+  }
+  case class ResponsivityReport(val site:Code[Site],val responsivity: Responsivity.Value)
 
 
   def stop(): Unit = {
@@ -185,14 +237,47 @@ with BatchingUtil
   }
 
 
+  private val isSiteApiVersionSupported: String => Boolean = _ == "1.2.3"
+
+  /**
+   *
+   * @param availabilityBuffer used to collect information on how well a site could be communicated with.
+   *                           This function should store a value for every site in [[config.sites]],
+   *                           either [[Responsivity.failure]] or [[Responsivity.success]]
+   * @return a list of sites that responded with a site code that is supported by the MVH network.
+   */
+  private[core] def checkSiteApiVersion(availabilityBuffer:ListBuffer[ResponsivityReport]): Future[Seq[Code[Site]]] = {
+    Future.traverse(config.sites.keys.toSeq) { site =>
+      dipConnector.getApiVersion(site)
+        .map {
+          case Right(v) if isSiteApiVersionSupported(v) =>
+            availabilityBuffer += ResponsivityReport(site, Responsivity.success)
+            Some(site)
+          case Right(_) =>
+            availabilityBuffer += ResponsivityReport(site, Responsivity.success)
+            None
+          case Left(_) =>
+            availabilityBuffer += ResponsivityReport(site, Responsivity.failure)
+            None
+        }
+        .recover {
+          case _ =>
+            availabilityBuffer += ResponsivityReport(site, Responsivity.failure)
+            None
+        }
+    }.map(_.flatten)
+  }
+
   /**
    * Communicates with all the configured DIP nodes, queries them for new  [[Submission.Reports]],
    * i.e. with status [[Unsubmitted]], and stores them in the [[pollingQueue]]
    */
-  private[core] def pollReports: Future[Any] = {
-
+  private[core] def pollReports(validSites: Seq[Code[Site]],
+                                availabilityBuffer:ListBuffer[ResponsivityReport])
+  : Future[Any] = {
     log.info(s"Polling Reports from ${config.sites.size} sites with up to ${config.activeUseCases.size} usecases")
     config.sites.toList
+      .filter(configVal => validSites.contains(configVal._1))
       .sortBy(_._1.value) // Just for easier log reading: sort the sites alphabetically
       .traverse {
         case (site,info) =>
@@ -214,12 +299,14 @@ with BatchingUtil
                   pollingQueue.saveIfAbsent(reports)
 
                 case Success(Left(err)) =>
-                  log.error(s"Problem polling $useCase SubmissionReports of site $site: $err")
+                  log.error(s"Problem polling $useCase SubmissionReports of site $curSite: $err")
+                  availabilityBuffer += ResponsivityReport(curSite,Responsivity.failure)
               }
               // Recover lest the Future traversal be "short-circuited" into a failed Future
               .recover {
                 case t =>
-                  log.error(s"Error(s) occurred polling $useCase SubmissionReports of $site", t)
+                  log.error(s"Error(s) occurred polling $useCase SubmissionReports of $curSite", t)
+                  availabilityBuffer += ResponsivityReport(curSite,Responsivity.failure)
                   t.getMessage.asLeft
               }
           }
@@ -274,7 +361,7 @@ with BatchingUtil
    * to avoid deadlock in case more than 200 SubmissionReports were processed in parallel here.
    */
 
-  private[core] def confirmSubmissions: Future[Seq[Either[String,Submission.Report]]] =
+  private[core] def confirmSubmissions(availabilityBuffer:ListBuffer[ResponsivityReport]): Future[Seq[Either[String,Submission.Report]]] =
     batchTraverse(
       pollingQueue.entries(_.status == Submitted),
       nSimultaneousSubmissionConfirmations
@@ -292,12 +379,14 @@ with BatchingUtil
 
         // Logs either the error message from the submission confirmation request or from queue removal
         case Success(Left(msg)) =>
+          availabilityBuffer += ResponsivityReport(report.site.code,Responsivity.failure)
           log.error(msg)
       }
       // Recover lest the Future traversal be "short-circuited" into a failed Future
       .recover {
         case t =>
           log.error(s"Problem confirming submission: Site ${report.site.code}, TAN ${report.id} - ${t.getMessage}")
+          availabilityBuffer += ResponsivityReport(report.site.code,Responsivity.failure)
           t.getMessage.asLeft
       }
 

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -71,7 +71,8 @@ with BatchingUtil
 {
   private[core] var clock: Clock = Clock.systemUTC()
 
-  private def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport], now: Instant): Unit =
+  private def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport],
+                                           now: Instant): Unit =
     config.mongoUri match {
       case Some(uri) =>
         import cats.effect.unsafe.implicits.global
@@ -87,7 +88,8 @@ with BatchingUtil
           } yield ()
         }.unsafeRunAndForget()
       case None =>
-        log.warn("CCDN_MONGODB_URI is not configured; site availability reports will not be persisted")
+        log.warn("CCDN_MONGODB_URI is not configured; site availability " +
+          "reports will not be persisted")
     }
 
   /**
@@ -106,9 +108,9 @@ with BatchingUtil
 
 
   /**
-   * Regularly queries DIP sites for new submissions ([[pollReports]]), uploads them to
-   * BfArM ([[uploadReports]]) and sends a confirmation to dip sites ([[confirmSubmissions]]).
-   * The interval is retrieved from [[config#polling]]
+   * Regularly queries DIP sites for new submissions ([[pollReports]]), uploads
+   * them to BfArM ([[uploadReports]]) and sends a confirmation to dip sites
+   * ([[confirmSubmissions]]). The interval is retrieved from [[config#polling]]
    *
    * Before polling for new reports, the [[pollingQueue]] is checked for preexisting items,
    * which are pro  cessed before polling for new items in [[pollReports]]
@@ -178,16 +180,21 @@ with BatchingUtil
    */
   private[core] def conductReportingWorkflow(): Future[Unit] = {
 
-    log.info(s"Conducting scheduled reporting workflow ${if (pollingQueue.exists(_ => true)) "with" else "without"} preexisting items in the queue")
+    log.info(s"Conducting scheduled reporting workflow " +
+      s"${if (pollingQueue.exists(_ => true)) "with" else "without"} " +
+      s"preexisting items in the queue")
 
     def coalesceResponsivityReports(responseLog: ListBuffer[ResponsivityReport]) =
       responseLog
         .groupBy(_.site)
         .map { case (site, reports) =>
           val responsivity =
-            if (reports.forall(_.responsivity == Responsivity.success)) Responsivity.success
-            else if (reports.forall(_.responsivity == Responsivity.failure)) Responsivity.failure
-            else Responsivity.mixedSuccess
+            if (reports.forall(_.responsivity == Responsivity.success))
+              Responsivity.success
+            else if (reports.forall(_.responsivity == Responsivity.failure))
+              Responsivity.failure
+            else
+              Responsivity.mixedSuccess
           ResponsivityReport(site, responsivity)
         }
 
@@ -198,8 +205,9 @@ with BatchingUtil
     for {
       responseLog <- Future.successful(ListBuffer[ResponsivityReport]())
       validSites <- checkSiteApiVersion(responseLog)
-      // Start by draining the report queue, if non-empty (in case the service had been interrupted) and
-      // it thus contains reports whose upload hasn't been confirmed to the origin DIP), in order to avoid polling them again
+      // Start by draining the report queue, if non-empty (in case the service
+      // had been interrupted) and it thus contains reports whose upload hasn't
+      // been confirmed to the origin DIP), in order to avoid polling them again
       _ <- if (pollingQueue.exists(_.status == Unsubmitted)) uploadReports else Future.unit
       _ <- if (pollingQueue.exists(_.status == Submitted)) confirmSubmissions(responseLog) else Future.unit
       _ <- pollReports(validSites,responseLog)
@@ -212,7 +220,8 @@ with BatchingUtil
 
   /**
    * How a site responded to requests. A record can consist of multiple items
-   * for the same site and can be reduced to single value. Mixed reports reduce to [[mixedSuccess]]
+   * for the same site and can be reduced to single value. Mixed reports reduce
+   * to [[mixedSuccess]]
    */
   object Responsivity extends Enumeration {
     val success = Value("fully")
@@ -271,12 +280,16 @@ with BatchingUtil
 
   /**
    *
-   * @param availabilityBuffer used to collect information on how well a site could be communicated with.
-   *                           This function should store a value for every site in [[config.sites]],
-   *                           either [[Responsivity.failure]] or [[Responsivity.success]]
-   * @return a list of sites that responded with a site code that is supported by the MVH network.
+   * @param availabilityBuffer used to collect information on how well a site
+   *                           could be communicated with. This function should
+   *                           store a value for every site in [[config.sites]],
+   *                           either [[Responsivity.failure]] or
+   *                           [[Responsivity.success]]
+   * @return a list of sites that responded with a site code that is supported
+   *         by the MVH network.
    */
-  private[core] def checkSiteApiVersion(availabilityBuffer:ListBuffer[ResponsivityReport]): Future[Seq[Code[Site]]] = {
+  private[core] def checkSiteApiVersion(availabilityBuffer:ListBuffer[ResponsivityReport])
+  : Future[Seq[Code[Site]]] = {
     Future.traverse(config.sites.keys.toSeq) { site =>
       dipConnector.getApiVersion(site)
         .map {
@@ -299,13 +312,15 @@ with BatchingUtil
   }
 
   /**
-   * Communicates with all the configured DIP nodes, queries them for new  [[Submission.Reports]],
-   * i.e. with status [[Unsubmitted]], and stores them in the [[pollingQueue]]
+   * Communicates with all the configured DIP nodes, queries them for
+   * new  [[Submission.Reports]], i.e. with status [[Unsubmitted]], and stores
+   * them in the [[pollingQueue]]
    */
   private[core] def pollReports(validSites: Seq[Code[Site]],
                                 availabilityBuffer:ListBuffer[ResponsivityReport])
   : Future[Any] = {
-    log.info(s"Polling Reports from ${config.sites.size} sites with up to ${config.activeUseCases.size} usecases")
+    log.info(s"Polling Reports from ${config.sites.size} sites with up " +
+      s"to ${config.activeUseCases.size} usecases")
     config.sites.toList
       .filter(configVal => validSites.contains(configVal._1))
       .sortBy(_._1.value) // Just for easier log reading: sort the sites alphabetically
@@ -329,13 +344,15 @@ with BatchingUtil
                   pollingQueue.saveIfAbsent(reports)
 
                 case Success(Left(err)) =>
-                  log.error(s"Problem polling $useCase SubmissionReports of site $curSite: $err")
+                  log.error(s"Problem polling $useCase SubmissionReports of " +
+                    s"site $curSite: $err")
                   availabilityBuffer += ResponsivityReport(curSite,Responsivity.failure)
               }
               // Recover lest the Future traversal be "short-circuited" into a failed Future
               .recover {
                 case t =>
-                  log.error(s"Error(s) occurred polling $useCase SubmissionReports of $curSite", t)
+                  log.error(s"Error(s) occurred polling $useCase " +
+                    s"SubmissionReports of $curSite", t)
                   availabilityBuffer += ResponsivityReport(curSite,Responsivity.failure)
                   t.getMessage.asLeft
               }
@@ -347,8 +364,9 @@ with BatchingUtil
 
   /**
    * Communicates with the BfArM, sends them [[BfarmReport]] entities, each based
-   * on one of all the [[Submission.Report]] entities in the [[pollingQueue]] that are
-   * in status [[Unsubmitted]]. After this upload their status is changed to [[Submitted]]
+   * on one of all the [[Submission.Report]] entities in the [[pollingQueue]]
+   * that are in status [[Unsubmitted]]. After this upload their status is
+   * changed to [[Submitted]]
    */
   private[core] def uploadReports: Future[Seq[Either[String,Unit]]] = {
 
@@ -359,17 +377,20 @@ with BatchingUtil
         bfarmConnector.upload(BfarmReport(report))
           .map {
             case Right(_) =>
-              log.info(s"SubmissionReport Uploaded: Site ${report.site.code}, TAN ${report.id}")
+              log.info(s"SubmissionReport Uploaded: " +
+                s"Site ${report.site.code}, TAN ${report.id}")
               pollingQueue.replace(report.copy(status = Submitted))
 
             case err @ Left(msg) =>
-              log.error(s"Problem uploading SubmissionReport: Site ${report.site.code}, TAN ${report.id} - $msg")
+              log.error(s"Problem uploading SubmissionReport: " +
+                s"Site ${report.site.code}, TAN ${report.id} - $msg")
               err
           }
           // Recover lest the Future traversal be "short-circuited" into a failed Future 
           .recover {
             case t =>
-              log.error(s"Problem uploading SubmissionReport: Site ${report.site.code}, TAN ${report.id} - ${t.getMessage}")
+              log.error(s"Problem uploading SubmissionReport: " +
+                s"Site ${report.site.code}, TAN ${report.id} - ${t.getMessage}")
               t.getMessage.asLeft
           }
     )
@@ -377,22 +398,25 @@ with BatchingUtil
   }
 
   /**
-   * Limits the number of submissions that can be processed simultaneously in [[confirmSubmissions]],
-   * which is additionally limited by the actual number of available threads
+   * Limits the number of submissions that can be processed simultaneously
+   * in [[confirmSubmissions]], which is additionally limited by the actual
+   * number of available threads
    */
   private[core] val nSimultaneousSubmissionConfirmations:Int = 50
 
   /**
-   * Send "submission confirmations" to the DIP nodes for each SubmissionReport that has
-   * been successfully submitted to BfArM. If successful the SubmissionReport is removed from [[pollingQueue]]
+   * Send "submission confirmations" to the DIP nodes for each SubmissionReport
+   * that has been successfully submitted to BfArM. If successful the
+   * SubmissionReport is removed from [[pollingQueue]]
    *
-   * NOTE: Given that some DIP nodes are placed behind an Apache Tomcat server, which only
-   * handles up to 200 sockets simultaneously by default, explicit batching is applied
-   * to avoid deadlock in case more than 200 SubmissionReports were processed in parallel here.
+   * NOTE: Given that some DIP nodes are placed behind an Apache Tomcat server,
+   * which only handles up to 200 sockets simultaneously by default, explicit
+   * batching is applied to avoid deadlock in case more than 200
+   * SubmissionReports were processed in parallel here.
    */
 
-  private[core] def confirmSubmissions(availabilityBuffer:ListBuffer[ResponsivityReport]):
-  Future[Seq[Either[String,Submission.Report]]] =
+  private[core] def confirmSubmissions(availabilityBuffer:ListBuffer[ResponsivityReport])
+  :Future[Seq[Either[String,Submission.Report]]] =
     batchTraverse[Submission.Report, Seq, Future, Either[String, Submission.Report]](
       pollingQueue.entries(_.status == Submitted),
       nSimultaneousSubmissionConfirmations
@@ -410,7 +434,8 @@ with BatchingUtil
           log.debug(s"Submission confirmed: Site ${report.site.code}, " +
             s"TAN ${report.id}")
 
-        // Logs either the error message from the submission confirmation request or from queue removal
+        //Logs either the error message from the submission confirmation request
+        // or from queue removal
         case Success(Left(msg)) =>
           availabilityBuffer += ResponsivityReport(report.site.code,Responsivity.failure)
           log.error(msg)

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -9,6 +9,10 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 import cats.syntax.either._
 import cats.syntax.traverse._
+import cats.effect.IO
+import mongo4cats.bson.Document
+import mongo4cats.bson.syntax._
+import mongo4cats.client.MongoClient
 import de.dnpm.dip.util.Logging
 import de.dnpm.dip.model.NGSReport
 import de.dnpm.dip.service.mvh.Submission
@@ -165,11 +169,11 @@ with BatchingUtil
       report.id,
       config.submitterId(report.site.code),
       config.dataNodeIds(report.useCase),
-      report.useCase match { 
+      report.useCase match {
         case MTB => Oncological
         case RD  => Rare
       },
-      report.sequencingType.collect { 
+      report.sequencingType.collect {
         case GenomeLongRead  => LibraryType.WGSLr
         case GenomeShortRead => LibraryType.WGS
         case Exome           => LibraryType.WES
@@ -182,7 +186,7 @@ with BatchingUtil
 
 
   /**
-   * Communicates with all the configured DIP nodes, queries them for new  [[Submission.Reports]], 
+   * Communicates with all the configured DIP nodes, queries them for new  [[Submission.Reports]],
    * i.e. with status [[Unsubmitted]], and stores them in the [[pollingQueue]]
    */
   private[core] def pollReports: Future[Any] = {
@@ -195,7 +199,7 @@ with BatchingUtil
           info.useCases.intersect(config.activeUseCases) // ensure only active use cases are polled
             .toList
             .traverse { useCase =>
-              
+
               log.debug(s"Polling $useCase SubmissionReports of $site")
               dipConnector.submissionReports(
                 site,
@@ -208,7 +212,7 @@ with BatchingUtil
                 case Success(Right(reports)) =>
                   log.debug(s"Enqueuing ${reports.size} $useCase SubmissionReports")
                   pollingQueue.saveIfAbsent(reports)
-            
+
                 case Success(Left(err)) =>
                   log.error(s"Problem polling $useCase SubmissionReports of site $site: $err")
               }
@@ -267,7 +271,7 @@ with BatchingUtil
    *
    * NOTE: Given that some DIP nodes are placed behind an Apache Tomcat server, which only
    * handles up to 200 sockets simultaneously by default, explicit batching is applied
-   * to avoid deadlock in case more than 200 SubmissionReports were processed in parallel here. 
+   * to avoid deadlock in case more than 200 SubmissionReports were processed in parallel here.
    */
 
   private[core] def confirmSubmissions: Future[Seq[Either[String,Submission.Report]]] =
@@ -278,11 +282,11 @@ with BatchingUtil
       report => dipConnector.confirmSubmitted(report).map {
         case Right(_) =>
           pollingQueue.removeFromQueue(report).map(_ => report)
-        
+
         case Left(msg) =>
           s"Problem confirming submission: Site ${report.site.code}, TAN ${report.id} - $msg".asLeft
       }
-      .andThen { 
+      .andThen {
         case Success(Right(_)) =>
           log.debug(s"Submission confirmed: Site ${report.site.code}, TAN ${report.id}")
 
@@ -290,13 +294,13 @@ with BatchingUtil
         case Success(Left(msg)) =>
           log.error(msg)
       }
-      // Recover lest the Future traversal be "short-circuited" into a failed Future 
+      // Recover lest the Future traversal be "short-circuited" into a failed Future
       .recover {
         case t =>
           log.error(s"Problem confirming submission: Site ${report.site.code}, TAN ${report.id} - ${t.getMessage}")
           t.getMessage.asLeft
       }
-      
+
     )
 
 }

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -69,27 +69,31 @@ class MVHReportingService
 extends Logging
 with BatchingUtil
 {
-
-  private val mongoUri: Option[String] = sys.env.get("CCDN_MONGODB_URI") //TODO maybe put this into config
-
   private[core] var clock: Clock = Clock.systemUTC()
 
   private def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport], now: Instant): Unit =
-    mongoUri.foreach { uri =>
-      import cats.effect.unsafe.implicits.global
-      MongoClient.fromConnectionString[IO](uri).use { client =>
-        for {
-          db   <- client.getDatabase("ccdn")
-          coll <- db.getCollection("siteAvailabilityReports")
-          docs  = reports.map(r => Document(
-            "site" := r.site.value,
-            "responsivity" := r.responsivity.toString,
-            "timestamp" := now)).toList
-          _    <- coll.insertMany(docs)
-        } yield ()
-      }.unsafeRunAndForget()
+    config.mongoUri match {
+      case Some(uri) =>
+        import cats.effect.unsafe.implicits.global
+        MongoClient.fromConnectionString[IO](uri).use { client =>
+          for {
+            db   <- client.getDatabase("ccdn")
+            coll <- db.getCollection("siteAvailabilityReports")
+            docs  = reports.map(r => Document(
+              "site" := r.site.value,
+              "responsivity" := r.responsivity.toString,
+              "timestamp" := now)).toList
+            _    <- coll.insertMany(docs)
+          } yield ()
+        }.unsafeRunAndForget()
+      case None =>
+        log.warn("CCDN_MONGODB_URI is not configured; site availability reports will not be persisted")
     }
 
+  /**
+   * Abstraction of logging responsivity reports for the purpose of having
+   * customization in unit tests
+   */
   private[core] var responsivitySink: (Iterable[ResponsivityReport], Instant) => Unit =
     writeSiteAvailabilityReports
 
@@ -129,7 +133,11 @@ with BatchingUtil
     log.info("Starting MVH Reporting service")
     log.info(s"Active Use Cases: ${config.activeUseCases.mkString(", ")}")
     log.info(s"Active sites: ${config.sites.keys.toList.sortBy(_.value).mkString(", ")}")
-    log.info(s"Mongodb uri: ${mongoUri}")
+    if(config.mongoUri.isDefined) {
+      log.debug(s"Mongodb uri: ${config.mongoUri.get}")
+    } else{
+      log.warn("Mongodb uri is undefined")
+    }
 
     val period =
       config.polling.period*toSeconds(config.polling.timeUnit)
@@ -218,7 +226,7 @@ with BatchingUtil
     val mixedSuccess = Value("partial")
     val failure = Value("offline")
   }
-  case class ResponsivityReport(val site:Code[Site],val responsivity: Responsivity.Value)
+  case class ResponsivityReport(site:Code[Site],responsivity: Responsivity.Value)
 
 
   def stop(): Unit = {

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -247,8 +247,16 @@ with BatchingUtil
 
 
   private val versionCutoverDate: LocalDate = LocalDate.of(2026, 6, 1)
-  private val isSiteApiVersionSupported: String => Boolean = version =>
-    LocalDate.now(clock).isBefore(versionCutoverDate) || (version >= "1.3")
+  private val versionPattern = raw"(\d+)\.(\d+)\..*".r
+  private val isSiteApiVersionSupported: String => Boolean = {
+    case versionPattern(major, minor) =>
+      LocalDate.now(clock).isBefore(versionCutoverDate) ||
+        (major.toInt > 1 || (major.toInt == 1 && minor.toInt >= 3))
+    case version =>
+      throw new IllegalArgumentException(
+        s"Version string '$version' does not match expected pattern '<number>.<number>.<anything>'"
+      )
+  }
 
   /**
    *

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -106,11 +106,6 @@ with BatchingUtil
     log.info("Starting MVH Reporting service")
     log.info(s"Active Use Cases: ${config.activeUseCases.mkString(", ")}")
     log.info(s"Active sites: ${config.sites.keys.toList.sortBy(_.value).mkString(", ")}")
-    if(config.mongoUri.isDefined) {
-      log.debug(s"Mongodb uri: ${config.mongoUri.get}")
-    } else{
-      log.warn("Mongodb uri is undefined")
-    }
 
     val period =
       config.polling.period*toSeconds(config.polling.timeUnit)

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -191,30 +191,23 @@ with BatchingUtil
           ResponsivityReport(site, responsivity)
         }
 
-            //responseLog stores notes about how well a site could be communicated with.
-            // checkSiteApiVersion will store a success item for every site that was
-            // available, so it is sufficient for the other functions to merely report
-            // failures. The endresult is reduced into a single value per site after the for loop.
-            for {
-              responseLog <- Future.successful(ListBuffer[ResponsivityReport]())
-              validSites <- checkSiteApiVersion(responseLog)
-              // Start by draining the report queue, if non-empty (in case the service had been interrupted) and
-              // it thus contains reports whose upload hasn't been confirmed to the origin DIP), in order to avoid polling them again
-              _ <- if (pollingQueue.exists(_.status == Unsubmitted)) uploadReports else Future.unit
-              _ <- if (pollingQueue.exists(_.status == Submitted)) confirmSubmissions(responseLog) else Future.unit
-              _ <- pollReports(validSites,responseLog)
-              _ <- uploadReports
-              _ <- confirmSubmissions(responseLog)
-            } yield {
-              writeSiteAvailabilityReports(coalesceResponsivityReports(responseLog))
-            }
-            ()
-          },
-          delay,
-          period,
-          TimeUnit.SECONDS
-        )
-      )
+    //responseLog stores notes about how well a site could be communicated with.
+    // checkSiteApiVersion will store a success item for every site that was
+    // available, so it is sufficient for the other functions to merely report
+    // failures. The endresult is reduced into a single value per site after the for loop.
+    for {
+      responseLog <- Future.successful(ListBuffer[ResponsivityReport]())
+      validSites <- checkSiteApiVersion(responseLog)
+      // Start by draining the report queue, if non-empty (in case the service had been interrupted) and
+      // it thus contains reports whose upload hasn't been confirmed to the origin DIP), in order to avoid polling them again
+      _ <- if (pollingQueue.exists(_.status == Unsubmitted)) uploadReports else Future.unit
+      _ <- if (pollingQueue.exists(_.status == Submitted)) confirmSubmissions(responseLog) else Future.unit
+      _ <- pollReports(validSites,responseLog)
+      _ <- uploadReports
+      _ <- confirmSubmissions(responseLog)
+    } yield {
+      responsivitySink(coalesceResponsivityReports(responseLog),Instant.now(clock))
+    }
   }
 
   /**
@@ -317,14 +310,14 @@ with BatchingUtil
       .filter(configVal => validSites.contains(configVal._1))
       .sortBy(_._1.value) // Just for easier log reading: sort the sites alphabetically
       .traverse {
-        case (site,info) =>
+        case (curSite,info) =>
           info.useCases.intersect(config.activeUseCases) // ensure only active use cases are polled
             .toList
             .traverse { useCase =>
 
-              log.debug(s"Polling $useCase SubmissionReports of $site")
+              log.debug(s"Polling $useCase SubmissionReports of $curSite")
               dipConnector.submissionReports(
-                site,
+                curSite,
                 useCase,
                 Submission.Report.Filter(
                   status = Some(Set(Submission.Report.Status.Unsubmitted))
@@ -398,21 +391,24 @@ with BatchingUtil
    * to avoid deadlock in case more than 200 SubmissionReports were processed in parallel here.
    */
 
-  private[core] def confirmSubmissions(availabilityBuffer:ListBuffer[ResponsivityReport]): Future[Seq[Either[String,Submission.Report]]] =
-    batchTraverse(
+  private[core] def confirmSubmissions(availabilityBuffer:ListBuffer[ResponsivityReport]):
+  Future[Seq[Either[String,Submission.Report]]] =
+    batchTraverse[Submission.Report, Seq, Future, Either[String, Submission.Report]](
       pollingQueue.entries(_.status == Submitted),
       nSimultaneousSubmissionConfirmations
     )(
-      report => dipConnector.confirmSubmitted(report).map {
+      report => (dipConnector.confirmSubmitted(report).map {
         case Right(_) =>
           pollingQueue.removeFromQueue(report).map(_ => report)
 
         case Left(msg) =>
-          s"Problem confirming submission: Site ${report.site.code}, TAN ${report.id} - $msg".asLeft
-      }
+          (s"Problem confirming submission: Site ${report.site.code}, " +
+            s"TAN ${report.id} - $msg").asLeft[Submission.Report]
+      }: Future[Either[String, Submission.Report]])
       .andThen {
         case Success(Right(_)) =>
-          log.debug(s"Submission confirmed: Site ${report.site.code}, TAN ${report.id}")
+          log.debug(s"Submission confirmed: Site ${report.site.code}, " +
+            s"TAN ${report.id}")
 
         // Logs either the error message from the submission confirmation request or from queue removal
         case Success(Left(msg)) =>
@@ -422,9 +418,10 @@ with BatchingUtil
       // Recover lest the Future traversal be "short-circuited" into a failed Future
       .recover {
         case t =>
-          log.error(s"Problem confirming submission: Site ${report.site.code}, TAN ${report.id} - ${t.getMessage}")
+          log.error(s"Problem confirming submission: Site ${report.site.code}, " +
+            s"TAN ${report.id} - ${t.getMessage}")
           availabilityBuffer += ResponsivityReport(report.site.code,Responsivity.failure)
-          t.getMessage.asLeft
+          t.getMessage.asLeft[Submission.Report]
       }
 
     )

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -207,7 +207,7 @@ with BatchingUtil
     // failures. The endresult is reduced into a single value per site after the for loop.
     for {
       responseLog <- Future.successful(ListBuffer[ResponsivityReport]())
-      validSites <- checkSiteApiVersion(responseLog)
+      validSites <- getApiCompatibleDipSites(responseLog)
       // Start by draining the report queue, if non-empty (in case the service
       // had been interrupted) and it thus contains reports whose upload hasn't
       // been confirmed to the origin DIP), in order to avoid polling them again
@@ -288,10 +288,10 @@ with BatchingUtil
    *                           store a value for every site in [[config.sites]],
    *                           either [[Responsivity.failure]] or
    *                           [[Responsivity.success]]
-   * @return a list of sites that responded with a site code that is supported
-   *         by the MVH network.
+   * @return a list of sites that responded with an API version code that is
+   *         supported by the MVH network.
    */
-  private[core] def checkSiteApiVersion(availabilityBuffer:ListBuffer[ResponsivityReport])
+  private[core] def getApiCompatibleDipSites(availabilityBuffer:ListBuffer[ResponsivityReport])
   : Future[Seq[Code[Site]]] = {
     Future.traverse(config.sites.keys.toSeq) { site =>
       dipConnector.getApiVersion(site)

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -145,13 +145,24 @@ with BatchingUtil
           () => {
             log.info(s"Conducting scheduled reporting workflow ${if (pollingQueue.exists(_ => true)) "with" else "without"} preexisting items in the queue")
 
+            def coalesceResponsivityReports(responseLog: ListBuffer[ResponsivityReport]) = {
+              responseLog
+                .groupBy(_.site)
+                .map { case (site, reports) =>
+                  val responsivity =
+                    if (reports.forall(_.responsivity == Responsivity.success)) Responsivity.success
+                    else if (reports.forall(_.responsivity == Responsivity.failure)) Responsivity.failure
+                    else Responsivity.mixedSuccess
+                  ResponsivityReport(site, responsivity)
+                }
+            }
+
             //responseLog stores notes about how well a site could be communicated with.
             // checkSiteApiVersion will store a success item for every site that was
             // available, so it is sufficient for the other functions to merely report
             // failures. The endresult is reduced into a single value per site after the for loop.
-            val responseLog: ListBuffer[ResponsivityReport] = ListBuffer()
-
             for {
+              responseLog <- Future.successful(ListBuffer[ResponsivityReport]())
               validSites <- checkSiteApiVersion(responseLog)
               // Start by draining the report queue, if non-empty (in case the service had been interrupted) and
               // it thus contains reports whose upload hasn't been confirmed to the origin DIP), in order to avoid polling them again
@@ -161,17 +172,7 @@ with BatchingUtil
               _ <- uploadReports
               _ <- confirmSubmissions(responseLog)
             } yield {
-              writeSiteAvailabilityReports(
-                responseLog
-                  .groupBy(_.site)
-                  .map { case (site, reports) =>
-                    val responsivity =
-                      if (reports.forall(_.responsivity == Responsivity.success)) Responsivity.success
-                      else if (reports.forall(_.responsivity == Responsivity.failure)) Responsivity.failure
-                      else Responsivity.mixedSuccess
-                    ResponsivityReport(site, responsivity)
-                  }
-              )
+              writeSiteAvailabilityReports(coalesceResponsivityReports(responseLog))
             }
             ()
           },

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -1,11 +1,12 @@
 package de.dnpm.ccdn.core
 
 
-import java.time.{Instant, LocalTime}
+import java.time.{Clock, Instant, LocalDate, LocalTime}
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.{Executors, ScheduledExecutorService}
 import java.util.concurrent.{TimeUnit, Future => JavaFuture}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration
 import scala.util.Success
 import cats.syntax.either._
 import cats.syntax.traverse._
@@ -71,19 +72,26 @@ with BatchingUtil
 
   private val mongoUri: Option[String] = sys.env.get("CCDN_MONGODB_URI") //TODO maybe put this into config
 
-  private def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport]): Unit =
+  private[core] var clock: Clock = Clock.systemUTC()
+
+  private def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport], now: Instant): Unit =
     mongoUri.foreach { uri =>
       import cats.effect.unsafe.implicits.global
       MongoClient.fromConnectionString[IO](uri).use { client =>
         for {
           db   <- client.getDatabase("ccdn")
           coll <- db.getCollection("siteAvailabilityReports")
-          now   = Instant.now
-          docs  = reports.map(r => Document("site" := r.site.value, "responsivity" := r.responsivity.toString, "timestamp" := now)).toList
+          docs  = reports.map(r => Document(
+            "site" := r.site.value,
+            "responsivity" := r.responsivity.toString,
+            "timestamp" := now)).toList
           _    <- coll.insertMany(docs)
         } yield ()
       }.unsafeRunAndForget()
     }
+
+  private[core] var responsivitySink: (Iterable[ResponsivityReport], Instant) => Unit =
+    writeSiteAvailabilityReports
 
 
   /**
@@ -106,7 +114,7 @@ with BatchingUtil
    *
    * Managed by [[pollingExecutor]]
    */
-  private var pollingTask: Option[JavaFuture[_]] = None
+  private[core] var pollingTask: Option[JavaFuture[_]] = None
 
   private val toSeconds =
     Map(
@@ -142,20 +150,38 @@ with BatchingUtil
     pollingTask =
       Some(
         pollingExecutor.scheduleAtFixedRate(
-          () => {
-            log.info(s"Conducting scheduled reporting workflow ${if (pollingQueue.exists(_ => true)) "with" else "without"} preexisting items in the queue")
+          () => try {
+            Await.result(conductReportingWorkflow(), Duration(45, TimeUnit.MINUTES))
+          } catch {
+            case _: java.util.concurrent.TimeoutException =>
+              log.error("Reporting workflow did not complete within the 45-minute timeout")
+          },
+          delay,
+          period,
+          TimeUnit.SECONDS
+        )
+      )
+  }
 
-            def coalesceResponsivityReports(responseLog: ListBuffer[ResponsivityReport]) = {
-              responseLog
-                .groupBy(_.site)
-                .map { case (site, reports) =>
-                  val responsivity =
-                    if (reports.forall(_.responsivity == Responsivity.success)) Responsivity.success
-                    else if (reports.forall(_.responsivity == Responsivity.failure)) Responsivity.failure
-                    else Responsivity.mixedSuccess
-                  ResponsivityReport(site, responsivity)
-                }
-            }
+  /**
+   * Executes one full cycle of the reporting workflow: checks site API versions,
+   * drains any pre-existing queue entries, polls new reports, uploads them to
+   * BfArM, and confirms back. Logs responsivity into [[responsivitySink]]
+   */
+  private[core] def conductReportingWorkflow(): Future[Unit] = {
+
+    log.info(s"Conducting scheduled reporting workflow ${if (pollingQueue.exists(_ => true)) "with" else "without"} preexisting items in the queue")
+
+    def coalesceResponsivityReports(responseLog: ListBuffer[ResponsivityReport]) =
+      responseLog
+        .groupBy(_.site)
+        .map { case (site, reports) =>
+          val responsivity =
+            if (reports.forall(_.responsivity == Responsivity.success)) Responsivity.success
+            else if (reports.forall(_.responsivity == Responsivity.failure)) Responsivity.failure
+            else Responsivity.mixedSuccess
+          ResponsivityReport(site, responsivity)
+        }
 
             //responseLog stores notes about how well a site could be communicated with.
             // checkSiteApiVersion will store a success item for every site that was
@@ -238,7 +264,9 @@ with BatchingUtil
   }
 
 
-  private val isSiteApiVersionSupported: String => Boolean = _ == "1.2.3"
+  private val versionCutoverDate: LocalDate = LocalDate.of(2026, 6, 1)
+  private val isSiteApiVersionSupported: String => Boolean = version =>
+    LocalDate.now(clock).isBefore(versionCutoverDate) || (version >= "1.3")
 
   /**
    *

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -3,8 +3,7 @@ package de.dnpm.ccdn.core
 
 import java.time.{Clock, Instant, LocalDate, LocalTime}
 import java.time.temporal.ChronoUnit
-import java.util.concurrent.{Executors, ScheduledExecutorService}
-import java.util.concurrent.{TimeUnit, Future => JavaFuture}
+import java.util.concurrent.{ConcurrentLinkedQueue, Executors, ScheduledExecutorService, TimeUnit, Future => JavaFuture}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 import scala.util.Success
@@ -22,7 +21,7 @@ import de.dnpm.ccdn.core.bfarm.BfarmConnector
 import de.dnpm.ccdn.core.dip.DipConnector
 import de.dnpm.dip.coding.Code
 
-import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 
 object MVHReportingService
@@ -188,7 +187,7 @@ with BatchingUtil
    * @param responseLog collected base data
    * @return one report per site
    */
-  private[core] def coalesceResponsivityReports(responseLog: ListBuffer[ResponsivityReport]) =
+  private[core] def coalesceResponsivityReports(responseLog: Iterable[ResponsivityReport]) =
     responseLog
       .groupBy(_.site)
       .map { case (site, reports) =>
@@ -223,7 +222,7 @@ with BatchingUtil
     // available, so it is sufficient for the other functions to merely report
     // failures. The endresult is reduced into a single value per site after the for loop.
     for {
-      responseLog <- Future.successful(ListBuffer[ResponsivityReport]())
+      responseLog <- Future.successful(new ConcurrentLinkedQueue[ResponsivityReport])
       validSites <- getApiCompatibleDipSites(responseLog)
       // Start by draining the report queue, if non-empty (in case the service
       // had been interrupted) and it thus contains reports whose upload hasn't
@@ -234,7 +233,7 @@ with BatchingUtil
       _ <- uploadReports
       _ <- confirmSubmissions(responseLog)
     } yield {
-      responsivitySink(coalesceResponsivityReports(responseLog),Instant.now(clock))
+      responsivitySink(coalesceResponsivityReports(responseLog.asScala),Instant.now(clock))
     }
   }
 
@@ -308,24 +307,24 @@ with BatchingUtil
    * @return a list of sites that responded with an API version code that is
    *         supported by the MVH network.
    */
-  private[core] def getApiCompatibleDipSites(availabilityBuffer:ListBuffer[ResponsivityReport])
+  private[core] def getApiCompatibleDipSites(availabilityBuffer:ConcurrentLinkedQueue[ResponsivityReport])
   : Future[Seq[Code[Site]]] = {
     Future.traverse(config.sites.keys.toSeq) { site =>
       dipConnector.getApiVersion(site)
         .map {
           case Right(v) if isSiteApiVersionSupported(v) =>
-            availabilityBuffer += ResponsivityReport(site, Responsivity.success,Some(v))
+            availabilityBuffer.add(ResponsivityReport(site, Responsivity.success,Some(v)))
             Some(site)
           case Right(v) =>
-            availabilityBuffer += ResponsivityReport(site, Responsivity.success, Some(v))
+            availabilityBuffer.add(ResponsivityReport(site, Responsivity.success, Some(v)))
             None
           case Left(_) =>
-            availabilityBuffer += ResponsivityReport(site, Responsivity.failure)
+            availabilityBuffer.add(ResponsivityReport(site, Responsivity.failure))
             None
         }
         .recover {
           case _ =>
-            availabilityBuffer += ResponsivityReport(site, Responsivity.failure)
+            availabilityBuffer.add(ResponsivityReport(site, Responsivity.failure))
             None
         }
     }.map(_.flatten)
@@ -337,7 +336,7 @@ with BatchingUtil
    * them in the [[pollingQueue]]
    */
   private[core] def pollReports(validSites: Seq[Code[Site]],
-                                availabilityBuffer:ListBuffer[ResponsivityReport])
+                                availabilityBuffer:ConcurrentLinkedQueue[ResponsivityReport])
   : Future[Any] = {
     log.info(s"Polling Reports from ${config.sites.size} sites with up " +
       s"to ${config.activeUseCases.size} usecases")
@@ -366,14 +365,14 @@ with BatchingUtil
                 case Success(Left(err)) =>
                   log.error(s"Problem polling $useCase SubmissionReports of " +
                     s"site $site: $err")
-                  availabilityBuffer += ResponsivityReport(site,Responsivity.failure)
+                  availabilityBuffer.add(ResponsivityReport(site,Responsivity.failure))
               }
               // Recover lest the Future traversal be "short-circuited" into a failed Future
               .recover {
                 case t =>
                   log.error(s"Error(s) occurred polling $useCase " +
                     s"SubmissionReports of $site", t)
-                  availabilityBuffer += ResponsivityReport(site,Responsivity.failure)
+                  availabilityBuffer.add(ResponsivityReport(site,Responsivity.failure))
                   t.getMessage.asLeft
               }
           }
@@ -435,7 +434,7 @@ with BatchingUtil
    * SubmissionReports were processed in parallel here.
    */
 
-  private[core] def confirmSubmissions(availabilityBuffer:ListBuffer[ResponsivityReport])
+  private[core] def confirmSubmissions(availabilityBuffer:ConcurrentLinkedQueue[ResponsivityReport])
   :Future[Seq[Either[String,Submission.Report]]] =
     batchTraverse[Submission.Report, Seq, Future, Either[String, Submission.Report]](
       pollingQueue.entries(_.status == Submitted),
@@ -457,7 +456,7 @@ with BatchingUtil
         //Logs either the error message from the submission confirmation request
         // or from queue removal
         case Success(Left(msg)) =>
-          availabilityBuffer += ResponsivityReport(report.site.code,Responsivity.failure)
+          availabilityBuffer.add(ResponsivityReport(report.site.code,Responsivity.failure))
           log.error(msg)
       }
       // Recover lest the Future traversal be "short-circuited" into a failed Future
@@ -465,7 +464,7 @@ with BatchingUtil
         case t =>
           log.error(s"Problem confirming submission: Site ${report.site.code}, " +
             s"TAN ${report.id} - ${t.getMessage}")
-          availabilityBuffer += ResponsivityReport(report.site.code,Responsivity.failure)
+          availabilityBuffer.add(ResponsivityReport(report.site.code,Responsivity.failure))
           t.getMessage.asLeft[Submission.Report]
       }
 

--- a/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MVHReportingService.scala
@@ -249,9 +249,8 @@ with BatchingUtil
       LocalDate.now(clock).isBefore(versionCutoverDate) ||
         (major.toInt > 1 || (major.toInt == 1 && minor.toInt >= 3))
     case version =>
-      throw new IllegalArgumentException(
-        s"Version string '$version' does not match expected pattern '<number>.<number>.<anything>'"
-      )
+      log.warn(s"Version string '$version' does not match expected pattern '<number>.<number>.<anything>'")
+      false
   }
 
   /**

--- a/core/src/main/scala/de/dnpm/ccdn/core/PersistenceService.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/PersistenceService.scala
@@ -1,0 +1,25 @@
+package de.dnpm.ccdn.core
+
+
+import java.time.Instant
+import de.dnpm.dip.util.{
+  SPI,
+  SPILoader
+}
+
+
+/**
+ * Supposed to longterm persist some data, for example whether DIP
+ * sites were available. Single implementation writes into mongoDB
+ */
+trait PersistenceService
+{
+  def writeSiteAvailabilityReports(
+    reports: Iterable[ResponsivityReport],
+    now: Instant
+  ): Unit
+}
+
+trait PersistenceServiceProvider extends SPI[PersistenceService]
+
+object PersistenceService extends SPILoader[PersistenceServiceProvider]

--- a/core/src/main/scala/de/dnpm/ccdn/core/ResponsivityReport.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/ResponsivityReport.scala
@@ -1,0 +1,18 @@
+package de.dnpm.ccdn.core
+
+
+import de.dnpm.dip.coding.Code
+import de.dnpm.dip.model.Site
+
+
+object Responsivity extends Enumeration {
+  val success      = Value("fully")
+  val mixedSuccess = Value("partial")
+  val failure      = Value("offline")
+}
+
+case class ResponsivityReport(
+  site: Code[Site],
+  responsivity: Responsivity.Value,
+  versionString: Option[String] = None
+)

--- a/core/src/main/scala/de/dnpm/ccdn/core/dip/DipConnector.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/dip/DipConnector.scala
@@ -37,7 +37,8 @@ trait DipConnectorOps[F[_],Env,Err]
   ): F[Either[Err,Submission.Report]]
 
   /**
-   * Asks the given site what version it is and returns the version string (extracted from json)
+   * Asks the given site what version it is and returns the version string
+   * (extracted from json)
    */
   def getApiVersion(site:Code[Site])(implicit env: Env): F[Either[Err,String]]
 

--- a/core/src/main/scala/de/dnpm/ccdn/core/dip/DipConnector.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/dip/DipConnector.scala
@@ -36,6 +36,11 @@ trait DipConnectorOps[F[_],Env,Err]
     implicit env: Env
   ): F[Either[Err,Submission.Report]]
 
+  /**
+   * Asks the given site what version it is and returns the version string (extracted from json)
+   */
+  def getApiVersion(site:Code[Site])(implicit env: Env): F[Either[Err,String]]
+
 }
 
 trait DipConnector extends DipConnectorOps[Future,ExecutionContext,String]

--- a/core/src/test/resources/META-INF/services/de.dnpm.ccdn.core.PersistenceServiceProvider
+++ b/core/src/test/resources/META-INF/services/de.dnpm.ccdn.core.PersistenceServiceProvider
@@ -1,0 +1,1 @@
+de.dnpm.ccdn.core.FakePersistenceServiceProvider

--- a/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
@@ -96,5 +96,5 @@ class FakeDIPConnector extends dip.DipConnector
    * Asks the given site what version it is and returns the version string (extracted from json)
    */
   override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext): Future[Either[String, String]] =
-    Future.successful(Right("1.2.3"))
+    Future.successful(Right("1.3.0"))
 }

--- a/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
@@ -81,8 +81,8 @@ class FakeDIPConnector extends dip.DipConnector
     if (confirmationsTakeTime) {
       Future {
         nActiveConfirmationWaits.updateAndGet(oldCount => {
-          maxSimultaneousConfirmationWaits.updateAndGet(oldMax =>
-            Math.max(oldMax, oldCount + 1))
+          maxSimultaneousConfirmationWaits.updateAndGet(
+            oldMax => Math.max(oldMax, oldCount + 1))
           oldCount + 1
         })
         Thread.sleep(FakeDIPConnector.uploadDelayMsec)

--- a/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
@@ -81,7 +81,8 @@ class FakeDIPConnector extends dip.DipConnector
     if (confirmationsTakeTime) {
       Future {
         nActiveConfirmationWaits.updateAndGet(oldCount => {
-          maxSimultaneousConfirmationWaits.updateAndGet(oldMax => Math.max(oldMax, oldCount + 1))
+          maxSimultaneousConfirmationWaits.updateAndGet(oldMax =>
+            Math.max(oldMax, oldCount + 1))
           oldCount + 1
         })
         Thread.sleep(FakeDIPConnector.uploadDelayMsec)
@@ -93,8 +94,10 @@ class FakeDIPConnector extends dip.DipConnector
     }
 
   /**
-   * Asks the given site what version it is and returns the version string (extracted from json)
+   * Asks the given site what version it is and returns the version string
+   * (extracted from json)
    */
-  override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext): Future[Either[String, String]] =
+  override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext)
+  : Future[Either[String, String]] =
     Future.successful(Right("1.3.0"))
 }

--- a/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
@@ -92,4 +92,9 @@ class FakeDIPConnector extends dip.DipConnector
       Future.successful(report.asRight)
     }
 
+  /**
+   * Asks the given site what version it is and returns the version string (extracted from json)
+   */
+  override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext): Future[Either[String, String]] =
+    Future.successful(Right("1.2.3"))
 }

--- a/core/src/test/scala/de/dnpm/ccdn/core/FakePersistenceService.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/FakePersistenceService.scala
@@ -1,0 +1,19 @@
+package de.dnpm.ccdn.core
+
+
+import java.time.Instant
+
+
+final class FakePersistenceServiceProvider extends PersistenceServiceProvider
+{
+  override def getInstance: PersistenceService =
+    new FakePersistenceService
+}
+
+class FakePersistenceService extends PersistenceService
+{
+  override def writeSiteAvailabilityReports(
+    reports: Iterable[ResponsivityReport],
+    now: Instant
+  ): Unit = ()
+}

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -103,7 +103,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     )
     testService.clock = Clock.fixed(preCutover, ZoneOffset.UTC)
 
-    testService.checkSiteApiVersion(ListBuffer.empty).map { validSites =>
+    testService.getApiCompatibleDipSites(ListBuffer.empty).map { validSites =>
       assertResult(Config.instance.sites.size)(validSites.size)
     }
   }
@@ -118,7 +118,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
-    testService.checkSiteApiVersion(ListBuffer.empty).map { validSites =>
+    testService.getApiCompatibleDipSites(ListBuffer.empty).map { validSites =>
       assertResult(Config.instance.sites.size)(validSites.size)
     }
   }
@@ -133,7 +133,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
-    testService.checkSiteApiVersion(ListBuffer.empty).map { validSites =>
+    testService.getApiCompatibleDipSites(ListBuffer.empty).map { validSites =>
       validSites must be(empty)
     }
   }

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -32,7 +32,8 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       Config.instance,
       ReportRepository.getInstance.get,
       fakeDipConnector,
-      fakeBfarmConnector
+      fakeBfarmConnector,
+      new FakePersistenceService
     )
 
   val sites = Config.instance.sites.keys.toSeq
@@ -70,27 +71,30 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     // Any version yields success before the cutover date.
     val fixedInstant = Instant.parse("2026-04-30T12:00:00Z")
 
+    val capturedReports = ListBuffer.empty[ResponsivityReport]
+    var capturedInstant: Option[Instant] = None
+    val capturingReporter = new PersistenceService {
+      override def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport], now: Instant): Unit = {
+        capturedReports ++= reports
+        capturedInstant = Some(now)
+      }
+    }
+
     val testService = new MVHReportingService(
       Config.instance,
       FakeReportRepository(),
       connectorReturningVersion("0.9.0"),
-      fakeBfarmConnector
+      fakeBfarmConnector,
+      capturingReporter
     )
     testService.clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
-
-    val capturedReports = ListBuffer.empty[testService.ResponsivityReport]
-    var capturedInstant: Option[Instant] = None
-    testService.responsivitySink = { (reports, now) =>
-      capturedReports ++= reports
-      capturedInstant = Some(now)
-    }
 
     for {
       _ <- testService.conductReportingWorkflow()
     } yield {
       capturedInstant must be(Some(fixedInstant))
       capturedReports must not be empty
-      assert(capturedReports.forall(_.responsivity == testService.Responsivity.success))
+      assert(capturedReports.forall(_.responsivity == Responsivity.success))
     }
   }
 
@@ -98,7 +102,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     val preCutover = Instant.parse("2026-05-31T23:59:59Z")
     val testService = new MVHReportingService(
       Config.instance, FakeReportRepository(), connectorReturningVersion("0.9.0"),
-      fakeBfarmConnector
+      fakeBfarmConnector, new FakePersistenceService
     )
     testService.clock = Clock.fixed(preCutover, ZoneOffset.UTC)
 
@@ -113,7 +117,8 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       Config.instance,
       FakeReportRepository(),
       connectorReturningVersion("1.3.0-RELEASE_5"),
-      fakeBfarmConnector
+      fakeBfarmConnector,
+      new FakePersistenceService
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
@@ -128,7 +133,8 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       Config.instance,
       FakeReportRepository(),
       connectorReturningVersion("1.2.4-BETA5-HOTFIX#133742"),
-      fakeBfarmConnector
+      fakeBfarmConnector,
+      new FakePersistenceService
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
@@ -153,18 +159,20 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
         Future.successful(Right(report))
     }
 
+    val capturedResponsivityReports = ListBuffer.empty[ResponsivityReport]
+    val capturingReporter = new PersistenceService {
+      override def writeSiteAvailabilityReports(reports: Iterable[ResponsivityReport], now: Instant): Unit =
+        capturedResponsivityReports ++= reports
+    }
+
     val testService = new MVHReportingService(
       Config.instance,
       FakeReportRepository(),
       failingDataConnector,
-      fakeBfarmConnector
+      fakeBfarmConnector,
+      capturingReporter
     )
     testService.clock = Clock.fixed(preCutover, ZoneOffset.UTC)
-
-    val capturedResponsivityReports = ListBuffer.empty[testService.ResponsivityReport]
-    testService.responsivitySink = { (reports, _) =>
-      capturedResponsivityReports ++= reports
-    }
 
     for {
       _ <- testService.conductReportingWorkflow()
@@ -174,7 +182,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       // they would be coalesced into one each
       capturedResponsivityReports.map(_.site).toSet mustEqual expectedSites
       assert(capturedResponsivityReports
-        .forall(_.responsivity == testService.Responsivity.mixedSuccess))
+        .forall(_.responsivity == Responsivity.mixedSuccess))
     }
   }
 
@@ -182,8 +190,8 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     val site = sites.head
     val version = "1.3.0"
     val reports = ListBuffer(
-      service.ResponsivityReport(site, service.Responsivity.success, Some(version)),
-      service.ResponsivityReport(site, service.Responsivity.failure, None)
+      ResponsivityReport(site, Responsivity.success, Some(version)),
+      ResponsivityReport(site, Responsivity.failure, None)
     )
     val coalesced = service.coalesceResponsivityReports(reports)
     Future.successful {
@@ -194,8 +202,8 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
   it must "coalesce versionString: report None if no report for the site had one" in {
     val site = sites.head
     val reports = ListBuffer(
-      service.ResponsivityReport(site, service.Responsivity.failure, None),
-      service.ResponsivityReport(site, service.Responsivity.failure, None)
+      ResponsivityReport(site, Responsivity.failure, None),
+      ResponsivityReport(site, Responsivity.failure, None)
     )
     val coalesced = service.coalesceResponsivityReports(reports)
     Future.successful {

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -5,9 +5,8 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.must.Matchers._
 import org.slf4j.LoggerFactory
 
-import java.util.concurrent.Executors
+import java.util.concurrent.{ConcurrentLinkedQueue, Executors}
 import scala.concurrent.ExecutionContext
-
 import java.time.{Clock, Instant, ZoneOffset}
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
@@ -42,13 +41,13 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     log.info("FakeDipConnector sending "+fakeDipConnector.nSubmissions+ " submissions per site")
     for {
       
-      _ <- service.pollReports(sites,ListBuffer.empty)
+      _ <- service.pollReports(sites,new ConcurrentLinkedQueue())
       
       _ = service.pollingQueue.entries(_ => true) must not be (empty)
 
       _ <- service.uploadReports
 
-      _ <- service.confirmSubmissions(ListBuffer.empty)
+      _ <- service.confirmSubmissions(new ConcurrentLinkedQueue())
 
     } yield service.pollingQueue.entries(_ => true) must be (empty)
   }
@@ -103,7 +102,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     )
     testService.clock = Clock.fixed(preCutover, ZoneOffset.UTC)
 
-    testService.getApiCompatibleDipSites(ListBuffer.empty).map { validSites =>
+    testService.getApiCompatibleDipSites(new ConcurrentLinkedQueue()).map { validSites =>
       assertResult(Config.instance.sites.size)(validSites.size)
     }
   }
@@ -118,7 +117,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
-    testService.getApiCompatibleDipSites(ListBuffer.empty).map { validSites =>
+    testService.getApiCompatibleDipSites(new ConcurrentLinkedQueue()).map { validSites =>
       assertResult(Config.instance.sites.size)(validSites.size)
     }
   }
@@ -133,7 +132,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
-    testService.getApiCompatibleDipSites(ListBuffer.empty).map { validSites =>
+    testService.getApiCompatibleDipSites(new ConcurrentLinkedQueue()).map { validSites =>
       validSites must be(empty)
     }
   }
@@ -221,11 +220,11 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     //run
     for{
 
-      _ <- service.pollReports(sites, ListBuffer.empty)
+      _ <- service.pollReports(sites, new ConcurrentLinkedQueue())
 
       _ <- service.uploadReports
 
-      _ <- service.confirmSubmissions(ListBuffer.empty)
+      _ <- service.confirmSubmissions(new ConcurrentLinkedQueue())
 
     } yield{
 

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext
 
 import java.time.{Clock, Instant, ZoneOffset}
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import de.dnpm.dip.coding.Code
 import de.dnpm.dip.model.Site
 import de.dnpm.dip.service.mvh.{Submission, UseCase}
@@ -60,8 +60,8 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     override def submissionReports(site: Code[Site], useCase: UseCase.Value, filter: Submission.Report.Filter)
         (implicit ec: ExecutionContext): Future[Either[String, Seq[Submission.Report]]] =
       Future.successful(Right(Seq.empty))
-    override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext): Future[Either[String, Unit]] =
-      Future.successful(Right(()))
+    override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext): Future[Either[String, Submission.Report]] =
+      Future.successful(Right(report))
   }
 
   it must "record Responsivity.success for every reachable site in conductPollingCycle and capture the correct timestamp" in {
@@ -73,7 +73,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       Config.instance,
       FakeReportRepository(),
       connectorReturningVersion("0.9.0"),
-      FakeBfarmConnector()
+      fakeBfarmConnector
     )
     testService.clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
 
@@ -96,7 +96,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
   it must "include all reachable sites as valid before the version-check cutover date, regardless of version" in {
     val preCutover = Instant.parse("2026-05-31T23:59:59Z")
     val testService = new MVHReportingService(
-      Config.instance, FakeReportRepository(), connectorReturningVersion("0.9.0"), FakeBfarmConnector()
+      Config.instance, FakeReportRepository(), connectorReturningVersion("0.9.0"), fakeBfarmConnector
     )
     testService.clock = Clock.fixed(preCutover, ZoneOffset.UTC)
 
@@ -108,7 +108,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
   it must "include sites with a 1.3.x version as valid on and after the cutover date" in {
     val onCutover = Instant.parse("2026-06-01T00:00:00Z")
     val testService = new MVHReportingService(
-      Config.instance, FakeReportRepository(), connectorReturningVersion("1.3.0-RELEASE_5"), FakeBfarmConnector()
+      Config.instance, FakeReportRepository(), connectorReturningVersion("1.3.0-RELEASE_5"), fakeBfarmConnector
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
@@ -120,7 +120,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
   it must "exclude sites with a 1.2.x version from valid sites on and after the cutover date" in {
     val onCutover = Instant.parse("2026-06-01T00:00:00Z")
     val testService = new MVHReportingService(
-      Config.instance, FakeReportRepository(), connectorReturningVersion("1.2.4-BETA5-HOTFIX#133742"), FakeBfarmConnector()
+      Config.instance, FakeReportRepository(), connectorReturningVersion("1.2.4-BETA5-HOTFIX#133742"), fakeBfarmConnector
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
@@ -138,15 +138,15 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       override def submissionReports(site: Code[Site], useCase: UseCase.Value, filter: Submission.Report.Filter)
           (implicit ec: ExecutionContext): Future[Either[String, Seq[Submission.Report]]] =
         Future.successful(Left("simulated data request failure"))
-      override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext): Future[Either[String, Unit]] =
-        Future.successful(Right(()))
+      override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext): Future[Either[String, Submission.Report]] =
+        Future.successful(Right(report))
     }
 
     val testService = new MVHReportingService(
       Config.instance,
       FakeReportRepository(),
       failingDataConnector,
-      FakeBfarmConnector()
+      fakeBfarmConnector
     )
     testService.clock = Clock.fixed(preCutover, ZoneOffset.UTC)
 

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -206,7 +206,6 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
 
       assertResult(service.nSimultaneousSubmissionConfirmations)(
         fakeDipConnector.maxSimultaneousConfirmationWaits.get())
-
     }
   }
 }

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -8,7 +8,12 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 
+import java.time.{Clock, Instant, ZoneOffset}
 import scala.collection.mutable.ListBuffer
+import scala.concurrent.{ExecutionContext, Future}
+import de.dnpm.dip.coding.Code
+import de.dnpm.dip.model.Site
+import de.dnpm.dip.service.mvh.{Submission, UseCase}
 
 
 
@@ -46,6 +51,82 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       _ <- service.confirmSubmissions(ListBuffer.empty)
 
     } yield service.pollingQueue.entries(_ => true) must be (empty)
+  }
+
+  // Helper to create a DipConnector that returns a fixed version string and empty reports
+  private def connectorReturningVersion(version: String) = new dip.DipConnector {
+    override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext): Future[Either[String, String]] =
+      Future.successful(Right(version))
+    override def submissionReports(site: Code[Site], useCase: UseCase.Value, filter: Submission.Report.Filter)
+        (implicit ec: ExecutionContext): Future[Either[String, Seq[Submission.Report]]] =
+      Future.successful(Right(Seq.empty))
+    override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext): Future[Either[String, Unit]] =
+      Future.successful(Right(()))
+  }
+
+  it must "record success responsivity for every reachable site in conductPollingCycle and capture the correct timestamp" in {
+    // Responsivity reflects connectivity (Right response), not version acceptance.
+    // Any version yields success before the cutover date.
+    val fixedInstant = Instant.parse("2026-04-30T12:00:00Z")
+
+    val testService = new MVHReportingService(
+      Config.instance,
+      FakeReportRepository(),
+      connectorReturningVersion("0.9.0"),
+      FakeBfarmConnector()
+    )
+    testService.clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+
+    val capturedReports = ListBuffer.empty[testService.ResponsivityReport]
+    var capturedInstant: Option[Instant] = None
+    testService.responsivitySink = { (reports, now) =>
+      capturedReports ++= reports
+      capturedInstant = Some(now)
+    }
+
+    for {
+      _ <- testService.conductReportingWorkflow()
+    } yield {
+      capturedInstant must be(Some(fixedInstant))
+      capturedReports must not be empty
+      assert(capturedReports.forall(_.responsivity == testService.Responsivity.success))
+    }
+  }
+
+  it must "include all reachable sites as valid before the version-check cutover date, regardless of version" in {
+    val preCutover = Instant.parse("2026-05-31T23:59:59Z")
+    val testService = new MVHReportingService(
+      Config.instance, FakeReportRepository(), connectorReturningVersion("0.9.0"), FakeBfarmConnector()
+    )
+    testService.clock = Clock.fixed(preCutover, ZoneOffset.UTC)
+
+    testService.checkSiteApiVersion(ListBuffer.empty).map { validSites =>
+      assertResult(Config.instance.sites.size)(validSites.size)
+    }
+  }
+
+  it must "include sites with a 1.3.x version as valid on and after the cutover date" in {
+    val onCutover = Instant.parse("2026-06-01T00:00:00Z")
+    val testService = new MVHReportingService(
+      Config.instance, FakeReportRepository(), connectorReturningVersion("1.3.0"), FakeBfarmConnector()
+    )
+    testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
+
+    testService.checkSiteApiVersion(ListBuffer.empty).map { validSites =>
+      assertResult(Config.instance.sites.size)(validSites.size)
+    }
+  }
+
+  it must "exclude sites with a 1.2.x version from valid sites on and after the cutover date" in {
+    val onCutover = Instant.parse("2026-06-01T00:00:00Z")
+    val testService = new MVHReportingService(
+      Config.instance, FakeReportRepository(), connectorReturningVersion("1.2.4-BETA5-HOTFIX#133742"), FakeBfarmConnector()
+    )
+    testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
+
+    testService.checkSiteApiVersion(ListBuffer.empty).map { validSites =>
+      validSites must be(empty)
+    }
   }
 
   it must " not process more submissions simultaneously than it has threads (non-deterministic)" in {

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -129,6 +129,42 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     }
   }
 
+  it must "produce Responsivity.mixedSuccess when version check succeeds but data requests fail" in {
+    val preCutover = Instant.parse("2026-04-30T12:00:00Z")
+
+    val failingDataConnector = new dip.DipConnector {
+      override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext): Future[Either[String, String]] =
+        Future.successful(Right("1.3.0"))
+      override def submissionReports(site: Code[Site], useCase: UseCase.Value, filter: Submission.Report.Filter)
+          (implicit ec: ExecutionContext): Future[Either[String, Seq[Submission.Report]]] =
+        Future.successful(Left("simulated data request failure"))
+      override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext): Future[Either[String, Unit]] =
+        Future.successful(Right(()))
+    }
+
+    val testService = new MVHReportingService(
+      Config.instance,
+      FakeReportRepository(),
+      failingDataConnector,
+      FakeBfarmConnector()
+    )
+    testService.clock = Clock.fixed(preCutover, ZoneOffset.UTC)
+
+    val capturedResponsivityReports = ListBuffer.empty[testService.ResponsivityReport]
+    testService.responsivitySink = { (reports, _) =>
+      capturedResponsivityReports ++= reports
+    }
+
+    for {
+      _ <- testService.conductReportingWorkflow()
+    } yield {
+      val expectedSites = Config.instance.sites.keys.toSet
+      //conductReportingWorkflow would have created more than one report, but they would be coalesced into one each
+      capturedResponsivityReports.map(_.site).toSet mustEqual expectedSites
+      assert(capturedResponsivityReports.forall(_.responsivity == testService.Responsivity.mixedSuccess))
+    }
+  }
+
   it must " not process more submissions simultaneously than it has threads (non-deterministic)" in {
     //configure bfarmconnecteor to halt for 100 msec during upload
 

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -179,6 +179,31 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     }
   }
 
+  it must "coalesce versionString: pick the version if any report for the site has one" in {
+    val site = sites.head
+    val version = "1.3.0"
+    val reports = ListBuffer(
+      service.ResponsivityReport(site, service.Responsivity.success, Some(version)),
+      service.ResponsivityReport(site, service.Responsivity.failure, None)
+    )
+    val coalesced = service.coalesceResponsivityReports(reports)
+    Future.successful {
+      assert(coalesced.exists(_.versionString.contains(version)))
+    }
+  }
+
+  it must "coalesce versionString: report None if no report for the site had one" in {
+    val site = sites.head
+    val reports = ListBuffer(
+      service.ResponsivityReport(site, service.Responsivity.failure, None),
+      service.ResponsivityReport(site, service.Responsivity.failure, None)
+    )
+    val coalesced = service.coalesceResponsivityReports(reports)
+    Future.successful {
+      assert(coalesced.forall(_.versionString.isEmpty))
+    }
+  }
+
   it must " not process more submissions simultaneously than it has threads (non-deterministic)" in {
     //configure bfarmconnecteor to halt for 100 msec during upload
 

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -8,6 +8,8 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 
+import scala.collection.mutable.ListBuffer
+
 
 
 final class MVHReportingServiceTests extends AsyncFlatSpec
@@ -21,7 +23,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
   val fakeDipConnector = new FakeDIPConnector
   val fakeBfarmConnector = new FakeBfarmConnector
 
-  val service = 
+  val service =
     new MVHReportingService(
       Config.instance,
       ReportRepository.getInstance.get,
@@ -29,18 +31,19 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       fakeBfarmConnector
     )
 
+  val sites = Config.instance.sites.keys.toSeq
 
   it must "handle multiple uploads from every DIP node in one go" in {
     log.info("FakeDipConnector sending "+fakeDipConnector.nSubmissions+ " submissions per site")
     for {
       
-      _ <- service.pollReports
+      _ <- service.pollReports(sites,ListBuffer.empty)
       
       _ = service.pollingQueue.entries(_ => true) must not be (empty)
 
       _ <- service.uploadReports
 
-      _ <- service.confirmSubmissions
+      _ <- service.confirmSubmissions(ListBuffer.empty)
 
     } yield service.pollingQueue.entries(_ => true) must be (empty)
   }
@@ -60,11 +63,11 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     //run
     for{
 
-      _ <- service.pollReports
+      _ <- service.pollReports(sites, ListBuffer.empty)
 
       _ <- service.uploadReports
 
-      _ <- service.confirmSubmissions
+      _ <- service.confirmSubmissions(ListBuffer.empty)
 
     } yield{
       assertResult(service.nSimultaneousSubmissionConfirmations)(fakeDipConnector.maxSimultaneousConfirmationWaits.get())

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -64,7 +64,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       Future.successful(Right(()))
   }
 
-  it must "record success responsivity for every reachable site in conductPollingCycle and capture the correct timestamp" in {
+  it must "record Responsivity.success for every reachable site in conductPollingCycle and capture the correct timestamp" in {
     // Responsivity reflects connectivity (Right response), not version acceptance.
     // Any version yields success before the cutover date.
     val fixedInstant = Instant.parse("2026-04-30T12:00:00Z")
@@ -108,7 +108,7 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
   it must "include sites with a 1.3.x version as valid on and after the cutover date" in {
     val onCutover = Instant.parse("2026-06-01T00:00:00Z")
     val testService = new MVHReportingService(
-      Config.instance, FakeReportRepository(), connectorReturningVersion("1.3.0"), FakeBfarmConnector()
+      Config.instance, FakeReportRepository(), connectorReturningVersion("1.3.0-RELEASE_5"), FakeBfarmConnector()
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 

--- a/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/MVHReportingServiceTests.scala
@@ -55,12 +55,14 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
 
   // Helper to create a DipConnector that returns a fixed version string and empty reports
   private def connectorReturningVersion(version: String) = new dip.DipConnector {
-    override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext): Future[Either[String, String]] =
+    override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext)
+    : Future[Either[String, String]] =
       Future.successful(Right(version))
     override def submissionReports(site: Code[Site], useCase: UseCase.Value, filter: Submission.Report.Filter)
         (implicit ec: ExecutionContext): Future[Either[String, Seq[Submission.Report]]] =
       Future.successful(Right(Seq.empty))
-    override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext): Future[Either[String, Submission.Report]] =
+    override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext)
+    : Future[Either[String, Submission.Report]] =
       Future.successful(Right(report))
   }
 
@@ -96,7 +98,8 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
   it must "include all reachable sites as valid before the version-check cutover date, regardless of version" in {
     val preCutover = Instant.parse("2026-05-31T23:59:59Z")
     val testService = new MVHReportingService(
-      Config.instance, FakeReportRepository(), connectorReturningVersion("0.9.0"), fakeBfarmConnector
+      Config.instance, FakeReportRepository(), connectorReturningVersion("0.9.0"),
+      fakeBfarmConnector
     )
     testService.clock = Clock.fixed(preCutover, ZoneOffset.UTC)
 
@@ -108,7 +111,10 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
   it must "include sites with a 1.3.x version as valid on and after the cutover date" in {
     val onCutover = Instant.parse("2026-06-01T00:00:00Z")
     val testService = new MVHReportingService(
-      Config.instance, FakeReportRepository(), connectorReturningVersion("1.3.0-RELEASE_5"), fakeBfarmConnector
+      Config.instance,
+      FakeReportRepository(),
+      connectorReturningVersion("1.3.0-RELEASE_5"),
+      fakeBfarmConnector
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
@@ -120,7 +126,10 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
   it must "exclude sites with a 1.2.x version from valid sites on and after the cutover date" in {
     val onCutover = Instant.parse("2026-06-01T00:00:00Z")
     val testService = new MVHReportingService(
-      Config.instance, FakeReportRepository(), connectorReturningVersion("1.2.4-BETA5-HOTFIX#133742"), fakeBfarmConnector
+      Config.instance,
+      FakeReportRepository(),
+      connectorReturningVersion("1.2.4-BETA5-HOTFIX#133742"),
+      fakeBfarmConnector
     )
     testService.clock = Clock.fixed(onCutover, ZoneOffset.UTC)
 
@@ -133,12 +142,15 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     val preCutover = Instant.parse("2026-04-30T12:00:00Z")
 
     val failingDataConnector = new dip.DipConnector {
-      override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext): Future[Either[String, String]] =
+      override def getApiVersion(site: Code[Site])(implicit env: ExecutionContext)
+      :Future[Either[String, String]] =
         Future.successful(Right("1.3.0"))
-      override def submissionReports(site: Code[Site], useCase: UseCase.Value, filter: Submission.Report.Filter)
+      override def submissionReports(site: Code[Site], useCase: UseCase.Value,
+                                     filter: Submission.Report.Filter)
           (implicit ec: ExecutionContext): Future[Either[String, Seq[Submission.Report]]] =
         Future.successful(Left("simulated data request failure"))
-      override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext): Future[Either[String, Submission.Report]] =
+      override def confirmSubmitted(report: Submission.Report)(implicit ec: ExecutionContext)
+      : Future[Either[String, Submission.Report]] =
         Future.successful(Right(report))
     }
 
@@ -159,9 +171,11 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       _ <- testService.conductReportingWorkflow()
     } yield {
       val expectedSites = Config.instance.sites.keys.toSet
-      //conductReportingWorkflow would have created more than one report, but they would be coalesced into one each
+      //conductReportingWorkflow would have created more than one report, but
+      // they would be coalesced into one each
       capturedResponsivityReports.map(_.site).toSet mustEqual expectedSites
-      assert(capturedResponsivityReports.forall(_.responsivity == testService.Responsivity.mixedSuccess))
+      assert(capturedResponsivityReports
+        .forall(_.responsivity == testService.Responsivity.mixedSuccess))
     }
   }
 
@@ -173,9 +187,11 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
     fakeDipConnector.maxSimultaneousConfirmationWaits.set(0)
 
     // testing setup has 39 clinic-usecases, so there can be no less than 39 uploads to run
-    val expectedNumReports = Config.instance.sites.flatMap(it => it._2.useCases).size * fakeDipConnector.nSubmissions
+    val expectedNumReports = Config.instance.sites
+      .flatMap(it => it._2.useCases).size * fakeDipConnector.nSubmissions
     //have more reports overall than nThreads
-    assert(expectedNumReports > service.nSimultaneousSubmissionConfirmations,"Setup assertion 1 failed")
+    assert(expectedNumReports > service.nSimultaneousSubmissionConfirmations,
+      "Setup assertion 1 failed")
 
     //run
     for{
@@ -187,7 +203,9 @@ final class MVHReportingServiceTests extends AsyncFlatSpec
       _ <- service.confirmSubmissions(ListBuffer.empty)
 
     } yield{
-      assertResult(service.nSimultaneousSubmissionConfirmations)(fakeDipConnector.maxSimultaneousConfirmationWaits.get())
+
+      assertResult(service.nSimultaneousSubmissionConfirmations)(
+        fakeDipConnector.maxSimultaneousConfirmationWaits.get())
 
     }
   }


### PR DESCRIPTION
Feature: A function to DipConnector was added that queries a sites API version. Starting 1st of June, further communication with the site is dependent on this version being "1.3.0" or greater. Whether the endpoints all responded properly is also remembered and reports of multiple calls are coalesced into a single report per site and polling loop. These reports of responsivity are stored in a mongoDB database, for which I added mongo4cats as dependency.
Style: Also reduced line length for easier diffs
Docs: Added a section to the README how building and deployment works.

Code is mostly generated with Claudecode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API version checks for DIP sites to determine compatibility
  * Optional MongoDB persistence for responsivity/availability reports
  * Time-aware reporting with improved per-site responsivity aggregation and tracking
  * More resilient scheduled reporting (timeouts are handled without failing the scheduler)

* **Documentation**
  * Added build & release instructions showing JAR assembly and Docker packaging

* **Tests**
  * Added/expanded tests for API-version handling, responsivity aggregation, reporting workflows, and failure cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnpm-dip/central-data-node/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->