### PR TITLE
build: Bump version of service-base

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import scala.util.Properties.envOrElse
 
 name := "dnpm-ccdn"  // Central Clinical Data Node
 ThisBuild / organization := "de.dnpm"
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / version      := envOrElse("VERSION","1.0.0")
 
 val ownerRepo  = envOrElse("REPOSITORY","dnpm-dip/central-data-node").split("/")
@@ -90,7 +90,7 @@ lazy val dependencies =
     val logback      = "ch.qos.logback"    %  "logback-classic"         % "1.5.18"
     val play_ahc     = "org.playframework" %% "play-ahc-ws-standalone"  % "3.0.7"
     val play_ahc_js  = "org.playframework" %% "play-ws-standalone-json" % "3.0.7"
-    val service_base = "de.dnpm.dip"       %% "service-base"            % "1.2.0"
+    val service_base = "de.dnpm.dip"       %% "service-base"            % "1.3.1"
     val mtb_dtos     = "de.dnpm.dip"       %% "mtb-dto-model"           % "1.1.2"
     val rd_dtos      = "de.dnpm.dip"       %% "rd-dto-model"            % "1.1.2"
   }

--- a/connectors/src/test/scala/de/dnpm/ccdn/connector/ArchivingReportRepositoryTests.scala
+++ b/connectors/src/test/scala/de/dnpm/ccdn/connector/ArchivingReportRepositoryTests.scala
@@ -34,13 +34,14 @@ class ArchivingReportRepositoryTests extends AnyFlatSpec
       Id(transferTan.toString),
       creationDate,
       Id("42"),
+      None,
       status,
       Coding[Site]("Uniklinik Tü","UKT"),
       UseCase.MTB,
       Submission.Type.Test,
-      None,None,
+      None,None,None,
       HealthInsurance.Type.SOZ,
-      None,None
+      None,None,None
     )
   }
   private def makeThreeReports:Seq[Submission.Report] = List(

--- a/core/src/main/scala/de/dnpm/ccdn/core/MTBMappings.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/MTBMappings.scala
@@ -550,7 +550,7 @@ trait MTBMappings extends Mappings[MTBPatientRecord]
                  )
                  .maxByOption(_.date)
                  .map(_.date),
-               record.patient.dateOfDeath.map(_.atEndOfMonth),
+               record.patient.dateOfDeath,
                Option(
                  record.getSystemicTherapies.map(_.latest).mapTo[List[FollowUp.Therapy]]
                )

--- a/core/src/main/scala/de/dnpm/ccdn/core/Mappings.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/Mappings.scala
@@ -117,7 +117,7 @@ trait Mappings[RecordType <: PatientRecord]
 
 
 //    val mvhCarePlan = record.getCarePlans.minBy(_.issuedOn)  // minBy safe here, because validation ensures non-empty careplan list for MVH submissions 
-    val mvhCarePlan = record.mvhCarePlan.get  // .get safe here, because validation ensures non-empty careplan list for MVH submissions 
+    val mvhCarePlan = record.indicationCarePlan.get  // .get safe here, because validation ensures non-empty careplan list for MVH submissions
 
     Metadata(
       Metadata.Submission(

--- a/core/src/main/scala/de/dnpm/ccdn/core/RDMappings.scala
+++ b/core/src/main/scala/de/dnpm/ccdn/core/RDMappings.scala
@@ -62,7 +62,7 @@ trait RDMappings extends Mappings[RDPatientRecord]
         record.diagnoses.toList.flatMap(_.onsetDate).minOption
           .orElse(record.hpoTerms.toList.flatMap(_.onsetDate).minOption)
           .getOrElse(YearMonth.of(1800,JANUARY)),
-        record.mvhCarePlan.get.issuedOn,
+        record.indicationCarePlan.get.issuedOn,
         record.diagnoses
           .toList
           .flatMap(_.familyControlLevel.map(_.code.enumValue))
@@ -474,7 +474,7 @@ trait RDMappings extends Mappings[RDPatientRecord]
             .exists(s => s == Confirmed || s == Partial),
           record.diagnoses.head.notes.flatMap(_.lastOption),
           record.patient.vitalStatus.code.enumValue,
-          record.patient.dateOfDeath.map(_.atEndOfMonth)
+          record.patient.dateOfDeath
         )
 
       } yield RDFollowUps(

--- a/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
+++ b/core/src/test/scala/de/dnpm/ccdn/core/FakeDIPConnector.scala
@@ -50,15 +50,15 @@ class FakeDIPConnector extends dip.DipConnector
       Id[TransferTAN](randomUUID.toString),
       LocalDateTime.now,
       Id[Patient](randomUUID.toString),
+      None,
       Submission.Report.Status.Unsubmitted,
       Coding[Site](site.value),
       useCase,
       Submission.Type.Initial,
       Some(NGSReport.Type.GenomeLongRead),
-      None,
+      None,None,
       HealthInsurance.Type.UNK,
-      None,
-      None
+      None, None, None
     )
 
 


### PR DESCRIPTION
Version of service-base is now 1.3.1
Version of Scala compiler is now 2.13.18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Scala version from 2.13.16 to 2.13.18
  * Updated service_base library dependency from 1.2.0 to 1.3.1

* **Refactor**
  * Adjusted internal data source for care plan extraction
  * Updated date handling logic for patient records
  * Synchronized test fixtures with updated data structure requirements

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnpm-dip/central-data-node/pull/18)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->